### PR TITLE
completed hover and concurrent events features

### DIFF
--- a/modules/backend/src/main/resources/events.json
+++ b/modules/backend/src/main/resources/events.json
@@ -1,103 +1,194 @@
 [
     {
         "eventType": "Start",
-        "time": "2025-07-16 14:00:00"
+        "time": "2025-08-05 14:00:00 UTC"
     },
     {
         "eventType": "Request",
         "id": "0",
-        "time": "2025-07-16 14:01:00",
+        "time": "2025-08-05 14:01:00 UTC",
         "request": "example.csv?time%3>=2025-01-03&time%<=2025-01-05"
     },
     {
         "eventType": "Response",
         "id": "0",
-        "time": "2025-07-16 14:01:01",
+        "time": "2025-08-05 14:01:01 UTC",
+        "status": 202
+    },
+    {
+        "eventType": "Request",
+        "id": "1",
+        "time": "2025-08-05 14:02:00 UTC",
+        "request": "test overlapping!!"
+    },
+    {
+        "eventType": "Response",
+        "id": "1",
+        "time": "2025-08-05 14:02:01 UTC",
         "status": 202
     },
     {
         "eventType": "Success",
         "id": "0",
-        "time": "2025-07-16 14:03:10",
-        "duration": 129 
+        "time": "2025-08-05 14:03:10 UTC",
+        "duration": 70
+    },
+    {
+        "eventType": "Failure",
+        "id": "1",
+        "time": "2025-08-05 14:04:45 UTC",
+        "msg": "overlapping test red!"
     },
     {
        	"eventType": "Request",
-      	"id": "1",
-      	"time": "2025-07-16 14:05:49",
+      	"id": "2",
+      	"time": "2025-08-05 14:05:49 UTC",
 	    "request": "bad request example"	
     },
     {
     	"eventType": "Response",
-        "id": "1",
-        "time": "2025-07-16 14:05:50",
+        "id": "2",
+        "time": "2025-08-05 14:05:50 UTC",
         "status": 404
     },
     { 
         "eventType": "Request",
-        "id": "2",
-        "time": "2025-07-16 14:12:50",
+        "id": "3",
+        "time": "2025-08-05 14:11:31 UTC",
         "request": "example3"
     
     }, 
     {
     	"eventType": "Response",
-        "id": "2",
-        "time": "2025-07-16 14:12:51",
+        "id": "3",
+        "time": "2025-08-05 14:11:32 UTC",
         "status": 202
     
     },
     {	
         "eventType": "Request",
-        "id": "3",
-        "time": "2025-07-16 14:20:30",
+        "id": "4",
+        "time": "2025-08-05 14:11:33 UTC",
         "request": "example4"
     
     }, 
     {
     	"eventType": "Response",
-        "id": "3",
-        "time": "2025-07-16 14:20:31",
+        "id": "4",
+        "time": "2025-08-05 14:11:34 UTC",
         "status": 202
     
     },
     {
     	"eventType": "Success",
-        "id": "2",
-        "time": "2025-07-16 14:27:20",
-        "duration": 270
+        "id": "4",
+        "time": "2025-08-05 14:11:45 UTC",
+        "duration": 12
     },
     {
     	"eventType": "Success",
         "id": "3",
-        "time": "2025-07-16 14:14:30",
-        "duration": 60
+        "time": "2025-08-05 14:12:51 UTC",
+        "duration": 80
     },
     {
         "eventType": "Request",
-        "id": "4",
-        "time": "2025-07-16 14:32:04",
+        "id": "5",
+        "time": "2025-08-05 14:13:40 UTC",
         "request": "example5 fail case"
     
     }, 
     {
     	"eventType": "Response",
-        "id": "4",
-        "time": "2025-07-16 14:32:05",
+        "id": "5",
+        "time": "2025-08-05 14:13:41 UTC",
         "status": 202
         
     },
     {
         "eventType": "Failure",
-        "id": "4",
-        "time": "2025-07-16 14:37:34", 
+        "id": "5",
+        "time": "2025-08-05 14:13:43 UTC", 
         "msg": "something went wrong"
     },
     {
         "eventType": "Request",
-        "id": "5",
-        "time": "2025-07-16 17:29:04",
-        "request": "example6 incomplete case"
-    
+        "id": "6",
+        "time": "2025-08-05 14:14:04 UTC",
+        "request": "example6 concurrent 1 case"
+    },
+    {
+        "eventType": "Request",
+        "id": "7",
+        "time": "2025-08-05 14:14:04 UTC",
+        "request": "example7 concurrent 2 case"
+    },
+    {
+        "eventType": "Response",
+        "id": "7",
+        "time": "2025-08-05 14:14:05 UTC",
+        "status": 202
+    },
+    {
+        "eventType": "Response",
+        "id": "6",
+        "time": "2025-08-05 14:14:05 UTC",
+        "status": 202
+    },
+    {
+        "eventType": "Request",
+        "id": "8",
+        "time": "2025-08-05 14:15:03 UTC",
+        "request": "example8 concurrent 3 case"
+    },
+    {
+        "eventType": "Response",
+        "id": "8",
+        "time": "2025-08-05 14:15:04 UTC",
+        "status": 202
+    },
+    {
+        "eventType": "Request",
+        "id": "9",
+        "time": "2025-08-05 14:15:32 UTC",
+        "request": "example9 concurrent 4 case"
+    },
+    {
+        "eventType": "Response",
+        "id": "9",
+        "time": "2025-08-05 14:15:33 UTC",
+        "status": 202
+    },
+    {
+    	"eventType": "Success",
+        "id": "6",
+        "time": "2025-08-05 14:16:05 UTC",
+        "duration": 121
+    },
+    {
+    	"eventType": "Success",
+        "id": "7",
+        "time": "2025-08-05 14:16:10 UTC",
+        "duration": 126
+    },
+    {
+    	"eventType": "Success",
+        "id": "8",
+        "time": "2025-08-05 14:17:00 UTC",
+        "duration": 117
+    },
+    {
+    	"eventType": "Success",
+        "id": "9",
+        "time": "2025-08-05 14:17:20 UTC",
+        "duration": 108
+    },
+    {
+    	"eventType": "Request",
+        "id": "10",
+        "time": "2025-08-05 14:59:32 UTC",
+        "request": "example10 ongoing case"
     }
+
+
 ]

--- a/modules/backend/src/main/resources/styles.css
+++ b/modules/backend/src/main/resources/styles.css
@@ -10,8 +10,7 @@
     display: flex;
     height: 70%;
     overflow: auto;
-    padding: 40px;
-}
+}   
 
 #bottom-panel
 {
@@ -27,6 +26,13 @@
 
 #canvas
 {
-    width: 1246px;
-    height: 10000px;
+    height: 100%;
+    width: 100%;
+    position: sticky;
+    top: 0;
 }
+
+#sizer{
+    height: 86400px;
+}
+

--- a/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
@@ -1,20 +1,23 @@
 package latis.logviz
 
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import java.time.format.DateTimeFormatter
+
+import org.scalajs.dom
+import org.scalajs.dom.HTMLElement
+import org.scalajs.dom.HTMLCanvasElement
+import org.scalajs.dom.MouseEvent
 import calico.html.io.{*, given}
 import cats.effect.IO
 import cats.effect.Resource
 import cats.syntax.all.*
+import cats.effect.std.Dispatcher
+import cats.effect.kernel.Ref
 import fs2.dom.HtmlElement
-import latis.logviz.model.Event
-import latis.logviz.model.RequestEvent
 import fs2.Stream
 
-import org.scalajs.dom
-import org.scalajs.dom.HTMLCanvasElement
-import cats.effect.std.Dispatcher
-import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
-import cats.effect.kernel.Ref
+import latis.logviz.model.Event
 import latis.logviz.model.Rectangle
 
 
@@ -23,104 +26,30 @@ import latis.logviz.model.Rectangle
   * Draws canvas components with log event details
   * 
   * @param stream stream of log events from EventClient
-  * @param eventsRef mapping of incomplete events to their id. id used to identify corresponding log events coming in from stream
-  * @param compEventsRef list of completed events with completed details
-  * @param rectRef list of rectangles to be drawn
+  * @param requestDetails div for hover feature
   */
-class EventComponent(stream: Stream[IO, Event], eventsRef: Ref[IO, Map[String, RequestEvent]], compEventsRef: Ref[IO, List[RequestEvent]], rectRef: Ref[IO, List[Rectangle]]) {
-  val timestampFormatter= java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:00") //couldnt get timezone error
-  val formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-  val pixelsPerSec = 1.0 //turns out I was using integer division before so I was getting value of 0. 
+class EventComponent(stream: Stream[IO, Event], requestDetails: HtmlElement[IO]) {
+  val timestampFormatter= DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:00 VV")
+  val pixelsPerSec = 1.0
 
  
   def render: Resource[IO, HtmlElement[IO]] = 
-    // canvas.flatMap{ c =>
-    //   div(c).evalTap{ t =>
-    //     val test = t.asInstanceOf[HTMLCanvasElement]
-    //     val context = test.getContext("2d").asInstanceOf[dom.CanvasRenderingContext2D]
-
-    //     for {
-    //       _   <- Resource.eval(parse)
-    //       _   <- animate(context)
-    //       _   <- hover(test)
-
-    //     } yield()
-    //   }
-    // }
     
     for {
-      canvasIO  <-  canvasTag(idAttr:= "canvas", widthAttr:= 1246, heightAttr:= 10000)
-      canvas    =   canvasIO.asInstanceOf[HTMLCanvasElement]
-      context   =   canvas.getContext("2d").asInstanceOf[dom.CanvasRenderingContext2D] 
-      _         <-  Resource.eval(parse)
-      _         <-  animate(canvas, context)
-      timeline  <-  div(idAttr:= "timeline", canvasIO)
+      canvasIO  <- canvasTag(idAttr:= "canvas")
+      sizer     <- div(idAttr:= "sizer")
+      timeline  <- div(idAttr:= "timeline", sizer, canvasIO)
+      canvas    =  canvasIO.asInstanceOf[HTMLCanvasElement]
+      context   =  canvas.getContext("2d").asInstanceOf[dom.CanvasRenderingContext2D]
+      eParser   <- Resource.eval(EventParser())
+      _         <- Resource.eval(stream.evalTap(event =>
+                    eParser.parse(event)).compile.drain)
+      scrollRef <- Resource.eval(Ref[IO].of(0.0))
+      isLive    <- Resource.eval(Ref[IO].of(true))
+      rectRef   <- Resource.eval(Ref[IO].of(List[Rectangle]()))
+      _         <- animate(canvas, context, sizer.asInstanceOf[HTMLElement], eParser, scrollRef, isLive, rectRef)
+      _         <- hover(canvas, requestDetails.asInstanceOf[HTMLElement], rectRef)
     } yield(timeline)
-
-
-  /**
-   * Parsing though log events from stream and mapping/appending (in)complete events
-   * 
-   * For each event in stream
-   *  - Start: since start has no id and is waiting on no other events, will append to list of completed events
-   *  - Request: is an incompleted event, waiting on additional log event(s) of same id
-   *  - Response: If we get an error status code, we have a completed event: remove mapping and add to list of completed events. Else, do nothing as we have successful response code so we will wait for an outcome log event.
-   *  - Success: Successful request event. Remove from map and append to list of completed events
-   *  - Failure: Failed request event. Remove from map and append to list of completed events
-  */
-  def parse =
-    stream.evalTap{event =>
-      event match {
-        case Event.Start(time) => compEventsRef.update(lst => RequestEvent.Server(time) +: lst)
-
-        case Event.Request(id, time, request) => eventsRef.update(ms => ms + (id -> RequestEvent.Request(time, request)))
-        case Event.Response(id, time, status) => 
-          if (status >= 400) {
-            for {
-              ms <- eventsRef.get
-              _  <- ms.get(id) match {
-                      case Some(value) => value match {
-                        case RequestEvent.Request(start, url) => compEventsRef.update(lst => RequestEvent.Failure(start, url, time, status.toString()) +: lst)
-                        case _ => throw new IllegalArgumentException("Event found that is not request, something seriously wrong")
-                      }
-                      case None => throw new IllegalArgumentException("No event of this id found")
-                      
-                    }
-              _   <- eventsRef.update(m => m - id)
-            } yield()
-          }
-          else {
-            IO.unit
-          }
-
-        case Event.Success(id, time, duration) => 
-          for {
-            ms  <- eventsRef.get
-            _   <- ms.get(id) match {
-                      case Some(value) => value match {
-                        case RequestEvent.Request(start, url) => compEventsRef.update(lst => RequestEvent.Success(start, url, time, duration) +: lst)
-                        case _ => throw new IllegalArgumentException("Event found that is not request, something went wrong")
-                      }
-                      case None => throw new IllegalArgumentException("No event found with this id")
-                    }
-            _   <- eventsRef.update(m => m - id)
-          } yield()
-
-        case Event.Failure(id, time, msg) => 
-          for {
-            ms  <- eventsRef.get
-            _   <- ms.get(id) match {
-                      case Some(value) => value match {
-                        case RequestEvent.Request(start, url) => compEventsRef.update(lst => RequestEvent.Failure(start, url, time, msg) +: lst)
-                        case _ => throw new IllegalArgumentException("Event found that is not request, something went wrong")
-                      }
-                      case None => throw new IllegalArgumentException("No event found with this id")
-                    }
-            _   <- eventsRef.update(m => m - id)
-          } yield()
-      }
-    }.compile.drain
-
   
   /**
    * Conversion to get position of a timestamp on the canvas
@@ -130,47 +59,8 @@ class EventComponent(stream: Stream[IO, Event], eventsRef: Ref[IO, Map[String, R
    * Same as saying how far off we are from the top of canvas(current time)
    * [[https://www.geeksforgeeks.org/java/java-time-duration-class-in-java/#]]
   */
-  def convertTime(timestamp: LocalDateTime, current: LocalDateTime) = 
+  private def convertTime(timestamp: ZonedDateTime, current: ZonedDateTime): Double = 
     java.time.Duration.between(timestamp, current).toSeconds() * pixelsPerSec
-
-
-  def makeRect(current: LocalDateTime) = 
-    for {
-      _ <- rectRef.set(List[Rectangle]())
-      _ <- eventsRef.get.flatTap{ m =>
-              m.toList.traverse{ (_, event) =>
-                event match {
-                  case RequestEvent.Request(start, url) => {
-                    val y = convertTime(LocalDateTime.parse(start, formatter), current)
-                    rectRef.update(lst => Rectangle(event, 150, y, 200, -y, "green") +: lst)
-                    }
-                  case _ => throw new IllegalArgumentException("Any other RequestEvent type should not be an incomplete event")
-                }
-              }
-            } 
-
-      _  <- compEventsRef.get.flatTap{ events =>
-              // println(events)
-              events.traverse {
-                case RequestEvent.Server(time) => {
-                  val y = convertTime(LocalDateTime.parse(time, formatter), current)
-                  rectRef.update(lst => Rectangle(RequestEvent.Server(time), 150, y, 200, -1, "green") +: lst)
-                  }
-                case RequestEvent.Request(start, url) => throw new IllegalArgumentException("Request event type should not be a completed event")
-                case RequestEvent.Success(start, url, end, duration) => {
-                  val y = convertTime(LocalDateTime.parse(start, formatter), current)
-                  val y_end = convertTime(LocalDateTime.parse(end, formatter), current)
-                  rectRef.update(lst => Rectangle(RequestEvent.Success(start, url, end, duration), 150, y, 200, y_end-y, "green") +: lst)
-                  }
-                case RequestEvent.Failure(start, url, end, msg) => {
-                  val y = convertTime(LocalDateTime.parse(start, formatter), current)
-                  val y_end = convertTime(LocalDateTime.parse(end, formatter), current)
-                  rectRef.update(lst => Rectangle(RequestEvent.Failure(start, url, end, msg), 150, y, 200, y_end-y, "red") +: lst)
-                  }
-              }
-            }
-
-    }yield()
 
   /**
    * (Re)Drawing canvas timestamp ticks and event rectangles
@@ -186,66 +76,66 @@ class EventComponent(stream: Stream[IO, Event], eventsRef: Ref[IO, Map[String, R
    * @param endTime the end of range of time that user may want to see
    * @param canvas
    * @param context 
+   * @param rects list of rectangles to draw
+   * @param cols number of columns to draw
+   * @param top   current scroll position from the top
+   * @param width total available space for columns to be drawn
   */
-  def drawCanvas(current: LocalDateTime, endTime: LocalDateTime, canvas: HTMLCanvasElement, context: dom.CanvasRenderingContext2D) =
-    context.clearRect(0,0,canvas.width, canvas.height)
+  private def drawCanvas(
+    current: ZonedDateTime,
+    endTime: ZonedDateTime,
+    canvas: HTMLCanvasElement,
+    context: dom.CanvasRenderingContext2D,
+    rects: List[Rectangle],
+    cols: Int,
+    top: Double,
+    width: Int
+  ): IO[Unit] =
 
-    val currTruncated = current.truncatedTo(ChronoUnit.MINUTES)
-    val mins = java.time.Duration.between(endTime, current).toMinutes.toInt
+    val topTS = current.minusSeconds((top / pixelsPerSec).toLong)
+    val currTruncated = topTS.truncatedTo(ChronoUnit.MINUTES)
+    val mins = ((math.min(convertTime(endTime, topTS), canvas.height.toDouble) /pixelsPerSec / 60)).toInt
+    val colors = List("lightgray", "white")
 
     for {
-      _  <- (0 to mins) 
-              .toList
-              .traverse{ min =>
-                val timestamp = currTruncated.minusMinutes(min)
-                val y = convertTime(timestamp, current).toDouble
-                // println(y)
-                // println(timestamp)
-                drawTS(context, y, timestamp)
-              }
-      _  <- rectRef.get.flatTap{ rects => 
-              rects.traverse{
-                case Rectangle(event, x, y, width, height, color) => drawRect(context, x, y, width, height, color)
-              }
-
+      _ <- IO(context.clearRect(0,0,canvas.width, canvas.height))
+      _ <- (0 until cols).toList
+            .traverse { col => 
+              val colWidth = width / cols
+              val x = 150 + colWidth * col
+              val color = colors(col % 2)
+              drawRect(context, x, 0, colWidth, canvas.height, color)
             }
-      // _  <- eventsRef.get.flatTap{ m =>
-      //         m.toList.traverse{ (_, event) =>
-      //           event match {
-      //             case RequestEvent.Request(start, url) => {
-      //               val y = convertTime(LocalDateTime.parse(start, formatter), current)
-      //               // drawLine(150, y, 200, "green")}
-      //               drawRect(context, 150, y, 200, -y, "green")}
-      //             case _ => throw new IllegalArgumentException("Any other RequestEvent type should not be an incomplete event")
-      //           }
-      //         }
-      //       }
-      // _  <- compEventsRef.get.flatTap{ events =>
-      //         // println(events)
-      //         events.traverse {
-      //           case RequestEvent.Server(time) => {
-      //             val y = convertTime(LocalDateTime.parse(time, formatter), current)
-      //             drawRect(context, 150, y, 200, 2, "green") }
-      //           case RequestEvent.Request(start, url) => throw new IllegalArgumentException("Request event type should not be a completed event")
-      //           case RequestEvent.Success(start, url, end, duration) => { //now that I am not using duration, need to figure out what to do with it
-      //             val y = convertTime(LocalDateTime.parse(start, formatter), current)
-      //             val y_end = convertTime(LocalDateTime.parse(end, formatter), current)
-      //             drawRect(context, 150, y, 200, y_end-y, "green")}
-      //           case RequestEvent.Failure(start, url, end, msg) => {
-      //             val y = convertTime(LocalDateTime.parse(start, formatter), current)
-      //             val y_end = convertTime(LocalDateTime.parse(end, formatter), current)
-      //             drawRect(context, 150, y, 200, y_end-y, "red")}
-      //         }
-      //       }
+      _ <- (0 to mins).toList
+            .traverse{ min =>
+              val timestamp = currTruncated.minusMinutes(min)
+              val y = convertTime(timestamp, topTS).toDouble
+              drawTS(context, y, timestamp)
+            }
+      _ <- rects.traverse{
+            case Rectangle(event, x, y, width, height, color) => 
+              drawRect(context, x, y, width, height, color)
+            }
     } yield()
 
 
-  def drawRect(context: dom.CanvasRenderingContext2D, x: Double, y: Double, width: Double, duration: Double, color: String) = IO {
+  private def drawRect(
+    context: dom.CanvasRenderingContext2D,
+    x: Double,
+    y: Double,
+    width: Double,
+    duration: Double,
+    color: String
+  ): IO[Unit] = IO {
     context.fillStyle = color
     context.fillRect(x, y, width, duration)
   }
   
-  def drawTS(context: dom.CanvasRenderingContext2D, y: Double, timestamp: LocalDateTime) = IO {
+  private def drawTS(
+    context: dom.CanvasRenderingContext2D,
+    y: Double,
+    timestamp: ZonedDateTime
+    ): IO[Unit] = IO {
     context.font = ("helvectica")
     context.fillStyle = "black"
     context.fillText(timestamp.format(timestampFormatter), 0, y)}
@@ -253,23 +143,106 @@ class EventComponent(stream: Stream[IO, Event], eventsRef: Ref[IO, Map[String, R
   /**
    * Animate canvas on the browser
    * 
+   * (Re) creates list of rectangles to be drawn on canvas at each animation frame
+   * 
    * Used dispatcher utility to use requestAnimationFrame as it takes in a js callback function. 
-   * Within our function, we call go which gets the current time, redraws canvas and calls requestAnimationFrame on itself to update frame
    * Dispatcher resource: [[https://typelevel.org/cats-effect/docs/std/dispatcher]]
+   * 
+   * @param canvas
+   * @param context
+   * @param sizer div for controlling how much space we have to scroll
+   * @param parser event parser holding list of events
+   * @param prevScrollPos ref holding the previous scroll position
+   * @param isLive ref determining whether to update live or not
+   * @param rectRef ref to hold list of rectangles to be drawn
   */
-  def animate(canvas: HTMLCanvasElement, context: dom.CanvasRenderingContext2D) =
+  private def animate(
+    canvas: HTMLCanvasElement,
+    context: dom.CanvasRenderingContext2D,
+    sizer: HTMLElement,
+    parser: EventParser,
+    prevScrollPos: Ref[IO, Double],
+    isLive: Ref[IO, Boolean],
+    rectRef: Ref[IO, List[Rectangle]]
+  ): Resource[IO, Dispatcher[IO]] =
     Dispatcher.sequential[IO] evalTap{ dispatcher => 
+
       def go(timestamp: Double): IO[Unit] = 
         for {
-          now <- IO(LocalDateTime.now(java.time.ZoneId.of("UTC"))) // for some reason local time zone doesnt work? America/Denver
-          end <- IO(now.toLocalDate.atStartOfDay()) //eventually take in user input to set the time range? default to same date start of day
-          _   <- makeRect(now)
-          _   <- drawCanvas(now, end, canvas, context)
-          _   <- IO.delay(dom.window.requestAnimationFrame(ts => dispatcher.unsafeRunAndForget(go(ts))))
+          top     <- IO(canvas.parentElement.scrollTop)
+          live    <- isLive.get
+          prevTop <- prevScrollPos.get
+          _       <- if (live || prevTop != top) {
+                      for {
+                        tlRect  <- IO(canvas.parentElement.getBoundingClientRect())
+                        height  =  tlRect.height
+                        _       <- IO(canvas.width = tlRect.width.toInt)
+                        _       <- IO(canvas.height = tlRect.height.toInt)
+                        width   <- IO(canvas.width - 150)     // offset by 150 for total width of canvas that rectangles should cover
+                        now     <- IO(ZonedDateTime.now(java.time.ZoneId.of("UTC")))
+                        end     <- IO(now.toLocalDate.atStartOfDay(now.getZone()))
+                        _       <- IO(sizer.style.height = s"${convertTime(end, now)+2}px")
+                        maxCol  <- parser.getMaxConcurrent()
+                        // _       <-  makeRect(now, em.events, em.compEvents, em.rectangles, em.maxCounter, height, top, width)
+                        events  <- parser.getEvents()
+                        rects   = Rectangles.makeRectangles(now, height, top, width/maxCol, events)
+                        _       <- rectRef.update(_ => rects)
+                        _       <- drawCanvas(now, end, canvas, context, rects, maxCol, top, width)
+                        _       <- prevScrollPos.update(_ => top)
+                        _       <- if (top == 0.0) {
+                                    isLive.update(_ => true)
+                                  } else {
+                                    isLive.update(_ => false)
+                                  }
+                      } yield ()
+                    } else {
+                      IO.unit
+                    }
+          _       <- IO.delay(dom.window.requestAnimationFrame(ts => 
+                      dispatcher.unsafeRunAndForget(go(ts))))
         } yield()
 
-      IO.delay(dom.window.requestAnimationFrame(ts => dispatcher.unsafeRunAndForget(go(ts))))
+      IO.delay(dom.window.requestAnimationFrame(ts => 
+        dispatcher.unsafeRunAndForget(go(ts))))
       }
 
+
+  /** 
+  * Displays event information on hover over an event rectangle
+  *
+  * @param canvas
+  * @param requestDetails HTML element to show event details of the event hovered over
+  * @param rectRef
+  */
+  private def hover(
+    canvas: HTMLCanvasElement,
+    requestDetails: HTMLElement,
+    rectRef: Ref[IO, List[Rectangle]]
+    ): Resource[IO, Dispatcher[IO]]  =
+    Dispatcher.sequential[IO] evalTap { dispatcher =>
+      IO(canvas.onmousemove = { (event: MouseEvent) =>
+        // gets position of mouse click, subtract that by the canvas dimensions and we get the mouse positions relative to the canvas.
+        val rect = canvas.getBoundingClientRect()
+        val mouseX = event.clientX - rect.left
+        val mouseY = event.clientY - rect.top
+
+        def checkHover: IO[Unit] = {
+          for {
+            _ <-  rectRef.get.flatTap { rects =>
+                    rects.traverse {
+                      case Rectangle(event, x, y, width, height, color) => {
+                        if (mouseX >= x && mouseX <= x + width && mouseY <= y && mouseY >= y + height) {
+                          IO(requestDetails.textContent = s"EVENT DETAILS: $event")
+                        } else {
+                          IO.unit
+                        }
+                      }
+                    }
+                  }
+          } yield ()
+        }
+        dispatcher.unsafeRunAndForget(checkHover)
+      })
+    }
 }
 

--- a/modules/frontend/src/main/scala/latis/logviz/EventParser.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventParser.scala
@@ -1,0 +1,144 @@
+package latis.logviz
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+import cats.effect.std.PQueue
+import cats.syntax.all.*
+
+import latis.logviz.model.RequestEvent
+import latis.logviz.model.Event
+
+trait EventParser {
+  def parse(event: Event): IO[Unit]
+  def getEvents(): IO[List[(RequestEvent, Int)]]
+  def getMaxConcurrent(): IO[Int]
+ 
+}
+
+object EventParser {
+  def apply(): IO[EventParser] = {
+    for {
+      //ongoing request events mapped to concurrent depth
+      eventsRef 		<- Ref[IO].of(Map[String, (RequestEvent, Int)]())
+      //completed events(with a finished time) mapped to concurrent depth
+      compEventsRef <- Ref[IO].of(List[(RequestEvent, Int)]())
+      //counter for number of concurrent events 
+      colCounter 		<- Ref[IO].of(0)
+      //max number of concurrent events at once
+      maxCounter 		<- Ref[IO].of(0)
+      //priority queue to keep track of which concurrency depth to tie a request event to
+      pq 						<- PQueue.bounded[IO, Int](100)
+      _ 						<- (0 to 99).toList.traverse(pq.offer(_))
+    } yield new EventParser {
+
+      /**
+      * Parsing though log events from stream and mapping/appending (in)complete events
+      * 
+      * For each event in stream
+      *  - Start: since start has no id and is waiting on no other events, will append to list of completed events
+      *  - Request: is an incompleted event, waiting on additional log event(s) of same id
+      *  - Response: If we get an error status code, we have a completed event: remove mapping and add to list of completed events. Else, do nothing as we have successful response code so we will wait for an outcome log event.
+      *  - Success: Successful request event. Remove from map and append to list of completed events
+      *  - Failure: Failed request event. Remove from map and append to list of completed events
+      */
+      // https://typelevel.org/cats-effect/docs/std/pqueue
+      override def parse(event: Event): IO[Unit] =
+        event match {
+          case Event.Start(time) =>
+            for {
+              cDepth	<- pq.take
+              c				<- colCounter.updateAndGet(c => c + 1)
+              _ 			<- maxCounter.update(prev => math.max(prev, c))
+              _ 			<- compEventsRef.update(lst => 
+                          (RequestEvent.Server(time), cDepth) +: lst
+                        )
+              _				<- colCounter.update(c => c - 1)
+              _				<- pq.offer(cDepth)
+            } yield()
+
+          case Event.Request(id, time, request) => 
+            for {
+              cDepth  <- pq.take
+              c       <- colCounter.updateAndGet(c => c + 1)
+              _       <- maxCounter.update(prev => math.max(prev, c))
+              _       <- eventsRef.update(map =>
+                          map + (id -> (RequestEvent.Request(time, request), cDepth))
+                        )
+            } yield ()
+
+          case Event.Response(id, time, status) => 
+            if (status >= 400) {
+              for {
+                map     <- eventsRef.get
+                cDepth  <- map.get(id) match {
+                            case Some((RequestEvent.Request(start, url), currDepth)) =>
+                              compEventsRef.update(lst => 
+                                (RequestEvent.Failure(start, url, time, status.toString),
+                                currDepth) +: lst)  
+                              >> IO(currDepth)
+                            case Some(_) => throw new IllegalArgumentException(
+                              "Got an event that is not request, something is wrong") 
+                            case None => throw new IllegalArgumentException(
+                              "No request of this id found??")
+                          }
+                _       <- eventsRef.update(m => m - id)
+                _       <- colCounter.update(c => c - 1)
+                _       <- pq.offer(cDepth)
+              } yield ()
+            } else {
+              IO.unit
+            }
+
+          case Event.Success(id, time, duration) => 
+            for {
+              map     <- eventsRef.get
+              cDepth  <- map.get(id) match {
+                          case Some((RequestEvent.Request(start, url), currDepth)) =>
+                            compEventsRef.update(lst =>
+                              (RequestEvent.Success(start, url, time, duration), 
+                              currDepth) +: lst)
+                            >> IO(currDepth)
+                          case Some(_) => throw new IllegalArgumentException(
+                            "Got an event that is not request, something is wrong") 
+                          case None => throw new IllegalArgumentException(
+                            "No request of this id found??")
+                        }
+              _       <- eventsRef.update(m => m - id)
+              _       <- colCounter.update(c => c - 1)
+              _       <- pq.offer(cDepth)
+            } yield ()
+
+          case Event.Failure(id, time, msg) => 
+            for {
+              map     <- eventsRef.get
+              cDepth  <- map.get(id) match {
+                          case Some((RequestEvent.Request(start, url), currDepth)) =>
+                            compEventsRef.update(lst =>
+                              (RequestEvent.Failure(start, url, time, msg), 
+                              currDepth) +: lst)
+                            >> IO(currDepth)
+                          case Some(_) => throw new IllegalArgumentException(
+                            "Got an event that is not request, something is wrong") 
+                          case None => throw new IllegalArgumentException(
+                            "No request of this id found??")
+                        }
+              _       <- eventsRef.update(m => m - id)
+              _       <- colCounter.update(c => c - 1)
+              _       <- pq.offer(cDepth)
+            } yield ()
+        }
+    
+      override def getEvents(): IO[List[(RequestEvent, Int)]] =
+        for {
+          incomp      <- eventsRef.get
+          events      <- IO(incomp.foldLeft(List[(RequestEvent, Int)]()){ (acc, map) =>
+                          map match
+                            case (_, (event, cDepth)) => (event, cDepth) :: acc
+                        })
+          compEvents  <- compEventsRef.get
+        } yield(compEvents ++ events)
+
+      override def getMaxConcurrent(): IO[Int] = maxCounter.get
+    }
+  }
+}

--- a/modules/frontend/src/main/scala/latis/logviz/Main.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/Main.scala
@@ -1,16 +1,12 @@
 package latis.logviz
 
 import calico.IOWebApp
+import calico.html.io.{*, given}
 import cats.effect.IO
 import cats.effect.Resource
 import fs2.dom.HtmlElement
 import org.http4s.dom.FetchClientBuilder
 import org.http4s.client.Client
-import latis.logviz.model.Event
-import calico.html.io.{*, given}
-import latis.logviz.model.RequestEvent
-import latis.logviz.model.Rectangle
-import cats.effect.kernel.Ref
 
 
 /**
@@ -25,21 +21,15 @@ object Main extends IOWebApp {
     val http: Client[IO] = FetchClientBuilder[IO].create
 
     val client: Resource[IO, EventClient] = Resource.eval(EventClient.fromHttpClient(http))
-    //will want to move the creation of these refs somewhere else to keep everything clean
-    val inCompleteEventsRef: Resource[IO, Ref[IO, Map[String, RequestEvent]]] = Resource.eval(Ref[IO].of(Map[String, RequestEvent]()))
-    val completeEventsRef: Resource[IO, Ref[IO, List[RequestEvent]]] = Resource.eval(Ref[IO].of(List[RequestEvent]()))
-    val rectangleRef: Resource[IO, Ref[IO, List[Rectangle]]] = Resource.eval(Ref[IO].of(List[Rectangle]()))
+
     for {
       ec          <- client
-      incompRef   <- inCompleteEventsRef
-      compRef     <- completeEventsRef
-      rectRef     <- rectangleRef
       header      <- div(idAttr:= "header")
       requestH1   <- h1(idAttr:= "request")
       bottom      <- div(idAttr:= "bottom-panel", div(idAttr:= "request-detail", requestH1))
-      component   =  new EventComponent(ec.getEvents, incompRef, compRef, rectRef)
+      component   =  new EventComponent(ec.getEvents, requestH1)
       timeline    <- component.render
-      html      <- div(idAttr:= "container", header, timeline, bottom)
+      html        <- div(idAttr:= "container", header, timeline, bottom)
       
   } yield html
 }

--- a/modules/frontend/src/main/scala/latis/logviz/Rectangles.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/Rectangles.scala
@@ -1,0 +1,95 @@
+package latis.logviz
+
+import java.time.Duration
+import java.time.format.DateTimeFormatter
+import java.time.ZonedDateTime
+
+import latis.logviz.model.RequestEvent
+import latis.logviz.model.Rectangle
+
+
+object Rectangles{
+  val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss VV")
+  val pixelsPerSec = 1.0
+  val startOffset = 150
+
+
+  /**
+    * Creates list of rectangles from given time range and list of events
+    * 
+    * For each event, we determine what its position would be relative to the current time at the top
+    * Then we determine whether any part of this event would be in the viewport of the canvas
+    * This is done by comparing its start position to the top and end position to the bottom.
+    * If the start position is greater than or equal to the top, then we know the event starts somewhere at or after the 
+    * start of the viewport. So that would either mean the start of the event is within the viewport or below it. 
+    * Then, since the end of the event must come after the start, the end will always be less than the start. 
+    * So, if the end time is less than the bottom of the viewport, we know the end time position must be either in the viewport or above
+    * Meaning that if both conditions are true, we have at least some part of the event that will be seen in the viewport so we make the rectangle to be drawn.
+    *
+    * @param currTime
+    * @param height
+    * @param top offset in pixels from the top of the "canvas" top of canvas is at that offset
+    * @param width width of each rectangle
+    * @param events 
+    * @return list of rectangles
+    */
+  def makeRectangles(
+    currTime: ZonedDateTime,
+    height: Double,
+    top: Double,
+    width: Int, 
+    events: List[(RequestEvent, Int)]
+  ): List[Rectangle] =
+    val bottomY = top + height
+    val rects: List[Rectangle] = events.foldLeft(List[Rectangle]()){ (acc, event) =>
+        event match {
+          case (RequestEvent.Server(time), cDepth) => 
+            val eventTime = ZonedDateTime.parse(time, formatter)
+            val y = Duration.between(eventTime, currTime).toSeconds() * pixelsPerSec
+
+            if (y >= top && y - 2 < bottomY) {
+              Rectangle((RequestEvent.Server(time), cDepth),
+              startOffset + cDepth * width, y - top, width, -2, "green") :: acc
+            } else {
+              acc
+            }
+
+          case (RequestEvent.Request(start, url), cDepth) =>
+            val eventTime = ZonedDateTime.parse(start, formatter)
+            val y = Duration.between(eventTime, currTime).toSeconds() * pixelsPerSec
+            if (y >= top) {
+              Rectangle((RequestEvent.Request(start, url), cDepth),
+              startOffset + cDepth * width, y-top, width, -(y-top), "green") :: acc
+            } else {
+              acc
+            }
+
+          case (RequestEvent.Success(start, url, end, duration), cDepth) =>
+            val eventTime = ZonedDateTime.parse(start, formatter)
+            val endTime = ZonedDateTime.parse(end, formatter)
+            val y = Duration.between(eventTime, currTime).toSeconds() * pixelsPerSec
+            val y_end = Duration.between(endTime, currTime).toSeconds() * pixelsPerSec
+
+            if (y >= top && y_end < bottomY) {
+              Rectangle((RequestEvent.Success(start, url, end, duration), cDepth),
+              startOffset + cDepth * width, y-top, width, y_end-y, "green") :: acc
+            } else {
+              acc
+            }
+          
+          case (RequestEvent.Failure(start, url, end, msg), cDepth) =>
+            val eventTime = ZonedDateTime.parse(start, formatter)
+            val endTime = ZonedDateTime.parse(end, formatter)
+            val y = Duration.between(eventTime, currTime).toSeconds() * pixelsPerSec
+            val y_end = Duration.between(endTime, currTime).toSeconds() * pixelsPerSec
+
+            if (y >= top && y_end < bottomY) {
+              Rectangle((RequestEvent.Failure(start, url, end, msg), cDepth),
+              startOffset + cDepth * width, y-top, width, y_end-y, "red") :: acc
+            } else {
+              acc
+            }
+        }
+    }
+    rects
+}

--- a/modules/shared/src/main/scala/latis/logviz/model/Event.scala
+++ b/modules/shared/src/main/scala/latis/logviz/model/Event.scala
@@ -36,7 +36,7 @@ enum RequestEvent{
   case Failure(start: String, url: String, end: String, msg: String)
 }
 
-final case class Rectangle(event: RequestEvent, x: Double, y: Double, width: Double, height: Double, color: String)
+final case class Rectangle(event: (RequestEvent, Int), x: Double, y: Double, width: Double, height: Double, color: String)
 
 /**
  * Decoding instructions for parsing different types of events


### PR DESCRIPTION
Following features were implemented:

- Hover
on every mouse move, get mouse position relative to canvas and check if overlapping with any rectangles
Resources used: 
https://stackoverflow.com/questions/24936457/scala-js-using-addeventlistener-to-add-events-to-objects
https://www.youtube.com/watch?v=xbdJf9MRL7A&list=PLN0tvDAN1yvSNbkHAwPzJ5O4pP_e2vyme&index=9&ab_channel=BananaCoding

- Concurrent events
Used priority queue to represent which columns are free. When a new request event comes in, pop from the PQ and assign mapping of that event to it's "concurrent depth". When event becomes complete, push the assigned column back to the PQ. 
Kept track of maximum number of concurrent events to be used to determine number of columns to draw as well as how large in width each column should be. 
PQ Resource: https://typelevel.org/cats-effect/docs/std/pqueue
Given an event and it's column, determine it's starting x axis by multiplying this depth by the width of each column. (offset of 150 also added to give space to timestamps)

- Canvas optimizations
-- Implemented virtual scrolling by using a sizer and having the canvas be the same size as the timeline and stick its position. 
Resource: https://gist.github.com/andyearnshaw/5cc3b6e158879481515abef8c20d92a7
Used scrollTop which gives us the scroll position offset from 0. (seems to be in pixels) 
Scroll position used to determine what the "new current" time of the canvas should be. 
[visual]
---Current time--
.
.
(canvas start) "current time" = Current time - scroll position in seconds
.
.
(canvas end)
.
.
---start of day--

-- Timeline now moves in "real-time" only when scrolled to the top of the canvas
Implemented using boolean ref and ref to keep track of previous scroll position. 
If scroll position at 0 then resume live updating-> redrawing canvas every animation frame
else don't keep redrawing if not scrolling and not at top of canvas.
This is to allow easy examination of specific time range without a distracting moving timeline. 
