### PR TITLE
Event source trait created

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,9 @@ lazy val backend = project
       "org.typelevel" %% "cats-core" % catsVersion,
       "org.typelevel" %% "cats-effect" % catsEffectVersion,
       "co.fs2" %% "fs2-core" % fs2Version,
+      "org.gnieh" %% "fs2-data-json" % "1.12.0",
+      "org.gnieh" %% "fs2-data-json-circe" % "1.12.0",
+      "org.gnieh" %% "fs2-data-text" % "1.12.0",
       "org.http4s" %% "http4s-core" % http4sVersion,
       "org.http4s" %% "http4s-dsl" % http4sVersion,
       "org.typelevel" %% "log4cats-slf4j" % log4catsVersion

--- a/modules/backend/src/main/scala/latis/logviz/EventSource.scala
+++ b/modules/backend/src/main/scala/latis/logviz/EventSource.scala
@@ -1,0 +1,12 @@
+package latis.logviz
+
+import java.time.LocalDateTime
+
+import cats.effect.IO
+import fs2.Stream
+
+import latis.logviz.model.Event
+
+trait EventSource {
+  def getEvents(start: LocalDateTime, end: LocalDateTime): Stream[IO, Event]
+}

--- a/modules/backend/src/main/scala/latis/logviz/JSONEventSource.scala
+++ b/modules/backend/src/main/scala/latis/logviz/JSONEventSource.scala
@@ -1,0 +1,60 @@
+package latis.logviz
+
+import java.time.format.DateTimeParseException
+import java.time.LocalDateTime
+
+import cats.effect.IO
+import cats.syntax.all.*
+import fs2.data.json.ast
+import fs2.data.json.circe.*
+import fs2.data.text.utf8.byteStreamCharLike
+import fs2.io.readClassLoaderResource
+import fs2.Stream
+
+import latis.logviz.model.Event
+
+val formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+
+class JSONEventSource extends EventSource {
+  override def getEvents(start: LocalDateTime, end: LocalDateTime): Stream[IO, Event] =
+
+    val byteStream: Stream[IO, Byte] = readClassLoaderResource[IO]("events.json")
+    
+    val decodedJson: Stream[IO, Event] = byteStream
+      .through(ast.parse)
+      .flatMap{ j => 
+        j.as[List[Event]] match {
+          case Right(events) => Stream.emits(events)
+          case Left(error) => 
+            Stream.raiseError[IO](new Exception(s"Decoding events.json failed. error: $error"))
+        }
+      }.filter{
+        case Event.Start(time) =>
+          Either.catchOnly[DateTimeParseException](LocalDateTime.parse(time, formatter)) match
+            case Left(value) => throw new IllegalArgumentException(
+              "Invalid time") 
+            case Right(value) => value.isAfter(start) && value.isBefore(end)
+        case Event.Request(id, time, request) =>
+          Either.catchOnly[DateTimeParseException](LocalDateTime.parse(time, formatter)) match
+            case Left(value) => throw new IllegalArgumentException(
+              "Invalid time") 
+            case Right(value) => value.isAfter(start) && value.isBefore(end)
+        case Event.Response(id, time, status) =>
+          Either.catchOnly[DateTimeParseException](LocalDateTime.parse(time, formatter)) match
+            case Left(value) => throw new IllegalArgumentException(
+              "Invalid time") 
+            case Right(value) => value.isAfter(start) && value.isBefore(end)
+        case Event.Success(id, time, duration) =>
+          Either.catchOnly[DateTimeParseException](LocalDateTime.parse(time, formatter)) match
+            case Left(value) => throw new IllegalArgumentException(
+              "Invalid time") 
+            case Right(value) => value.isAfter(start) && value.isBefore(end)
+        case Event.Failure(id, time, msg) =>
+          Either.catchOnly[DateTimeParseException](LocalDateTime.parse(time, formatter)) match
+            case Left(value) => throw new IllegalArgumentException(
+              "Invalid time") 
+            case Right(value) => value.isAfter(start) && value.isBefore(end)
+      }
+      decodedJson
+}


### PR DESCRIPTION
Created EventSource trait that will be used as an argument for LogvizRoutes down the line. 
This will determine the stream of events that we get when we call the /events endpoint. 

JSONEventSource is for the test JSON file with dummy events data. 
Used Isabelle's fs2 data json implementation for getting a stream of events from the json file. 
After creating stream, filtered out events using the to be received query parameters for start and end time. 

Once EventSource is actually going to be used, will convert to ZonedDateTime as needed. 