### PR TITLE
Server Sent Events

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,6 +76,7 @@ lazy val frontend = project
       "com.armanbilge" %%% "calico" % "0.2.3",
       "org.typelevel" %%% "cats-core" % catsVersion,
       "org.typelevel" %%% "cats-effect" % catsEffectVersion,
+      "io.circe" %%% "circe-parser" % circeVersion,
       "co.fs2" %%% "fs2-core" % fs2Version,
       "com.armanbilge" %%% "fs2-dom" % "0.2.1",
       "org.http4s" %%% "http4s-circe" % http4sVersion,
@@ -138,5 +139,5 @@ prodCompile := {
   IO.copyFile(js / "main.js", dst / "main.js")
 }
 
-addCommandAlias("runDev", "; devCompile; app/reStart")
+addCommandAlias("runDev", "; devCompile; app/reStart") // use app/run
 addCommandAlias("runProd", "; prodCompile; app/reStart")

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,8 @@ lazy val app = project
       "org.http4s" %% "http4s-ember-server" % http4sVersion,
       "org.typelevel" %% "log4cats-slf4j" % log4catsVersion,
       "ch.qos.logback" % "logback-classic" % "1.5.18" % Runtime
-    )
+    ),
+    run / fork := true
   )
 
 lazy val backend = project

--- a/build.sbt
+++ b/build.sbt
@@ -39,8 +39,7 @@ lazy val app = project
       "org.http4s" %% "http4s-ember-server" % http4sVersion,
       "org.typelevel" %% "log4cats-slf4j" % log4catsVersion,
       "ch.qos.logback" % "logback-classic" % "1.5.18" % Runtime
-    ),
-    run / fork := true // TODO: remove this
+    )
   )
 
 lazy val backend = project

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,8 @@ lazy val app = project
       "org.http4s" %% "http4s-ember-server" % http4sVersion,
       "org.typelevel" %% "log4cats-slf4j" % log4catsVersion,
       "ch.qos.logback" % "logback-classic" % "1.5.18" % Runtime
-    )
+    ),
+    run / fork := true
   )
 
 lazy val backend = project
@@ -51,6 +52,9 @@ lazy val backend = project
       "org.typelevel" %% "cats-core" % catsVersion,
       "org.typelevel" %% "cats-effect" % catsEffectVersion,
       "co.fs2" %% "fs2-core" % fs2Version,
+      "org.gnieh" %% "fs2-data-json" % "1.12.0",
+      "org.gnieh" %% "fs2-data-json-circe" % "1.12.0",
+      "org.gnieh" %% "fs2-data-text" % "1.12.0",
       "org.http4s" %% "http4s-core" % http4sVersion,
       "org.http4s" %% "http4s-dsl" % http4sVersion,
       "org.typelevel" %% "log4cats-slf4j" % log4catsVersion
@@ -82,7 +86,9 @@ lazy val shared = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "io.circe" %%% "circe-core" % circeVersion
+      "io.circe" %%% "circe-core" % circeVersion,
+      "co.fs2" %%% "fs2-core" % fs2Version,
+      "org.http4s" %%% "http4s-circe" % http4sVersion
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -40,12 +40,13 @@ lazy val app = project
       "org.typelevel" %% "log4cats-slf4j" % log4catsVersion,
       "ch.qos.logback" % "logback-classic" % "1.5.18" % Runtime
     ),
-    run / fork := true
+    run / fork := true // TODO: remove this
   )
 
 lazy val backend = project
   .in(file("modules/backend"))
   .dependsOn(shared.jvm)
+  .dependsOn(splunk)
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
@@ -57,7 +58,10 @@ lazy val backend = project
       "org.gnieh" %% "fs2-data-text" % "1.12.0",
       "org.http4s" %% "http4s-core" % http4sVersion,
       "org.http4s" %% "http4s-dsl" % http4sVersion,
-      "org.typelevel" %% "log4cats-slf4j" % log4catsVersion
+      "org.typelevel" %% "log4cats-slf4j" % log4catsVersion,
+      "com.github.pureconfig" %%% "pureconfig-core" % pureconfigVersion,
+      "com.github.pureconfig" %%% "pureconfig-cats-effect" % pureconfigVersion,
+      "com.github.pureconfig" %%% "pureconfig-http4s" % pureconfigVersion
     )
   )
 

--- a/modules/backend/src/main/resources/events.json
+++ b/modules/backend/src/main/resources/events.json
@@ -1,192 +1,192 @@
 [
     {
         "eventType": "Start",
-        "time": "2025-08-05 14:00:00 UTC"
+        "time": "2025-08-29T14:00:00.000"
     },
     {
         "eventType": "Request",
         "id": "0",
-        "time": "2025-08-05 14:01:00 UTC",
+        "time": "2025-08-29T14:01:00.000",
         "request": "example.csv?time%3>=2025-01-03&time%<=2025-01-05"
     },
     {
         "eventType": "Response",
         "id": "0",
-        "time": "2025-08-05 14:01:01 UTC",
+        "time": "2025-08-29T14:01:01.000",
         "status": 202
     },
     {
         "eventType": "Request",
         "id": "1",
-        "time": "2025-08-05 14:02:00 UTC",
+        "time": "2025-08-29T14:02:00.000",
         "request": "test overlapping!!"
     },
     {
         "eventType": "Response",
         "id": "1",
-        "time": "2025-08-05 14:02:01 UTC",
+        "time": "2025-08-29T14:02:01.000",
         "status": 202
     },
     {
         "eventType": "Success",
         "id": "0",
-        "time": "2025-08-05 14:03:10 UTC",
+        "time": "2025-08-29T14:03:10.000",
         "duration": 70
     },
     {
         "eventType": "Failure",
         "id": "1",
-        "time": "2025-08-05 14:04:45 UTC",
+        "time": "2025-08-29T14:04:45.000",
         "msg": "overlapping test red!"
     },
     {
        	"eventType": "Request",
       	"id": "2",
-      	"time": "2025-08-05 14:05:49 UTC",
+      	"time": "2025-08-29T14:05:49.000",
 	    "request": "bad request example"	
     },
     {
     	"eventType": "Response",
         "id": "2",
-        "time": "2025-08-05 14:05:50 UTC",
+        "time": "2025-08-29T14:05:50.000",
         "status": 404
     },
     { 
         "eventType": "Request",
         "id": "3",
-        "time": "2025-08-05 14:11:31 UTC",
+        "time": "2025-08-29T14:11:31.000",
         "request": "example3"
     
     }, 
     {
     	"eventType": "Response",
         "id": "3",
-        "time": "2025-08-05 14:11:32 UTC",
+        "time": "2025-08-29T14:11:32.000",
         "status": 202
     
     },
     {	
         "eventType": "Request",
         "id": "4",
-        "time": "2025-08-05 14:11:33 UTC",
+        "time": "2025-08-29T14:11:33.000",
         "request": "example4"
     
     }, 
     {
     	"eventType": "Response",
         "id": "4",
-        "time": "2025-08-05 14:11:34 UTC",
+        "time": "2025-08-29T14:11:34.000",
         "status": 202
     
     },
     {
     	"eventType": "Success",
         "id": "4",
-        "time": "2025-08-05 14:11:45 UTC",
+        "time": "2025-08-29T14:11:45.000",
         "duration": 12
     },
     {
     	"eventType": "Success",
         "id": "3",
-        "time": "2025-08-05 14:12:51 UTC",
+        "time": "2025-08-29T14:12:51.000",
         "duration": 80
     },
     {
         "eventType": "Request",
         "id": "5",
-        "time": "2025-08-05 14:13:40 UTC",
+        "time": "2025-08-29T14:13:40.000",
         "request": "example5 fail case"
     
     }, 
     {
     	"eventType": "Response",
         "id": "5",
-        "time": "2025-08-05 14:13:41 UTC",
+        "time": "2025-08-29T14:13:41.000",
         "status": 202
         
     },
     {
         "eventType": "Failure",
         "id": "5",
-        "time": "2025-08-05 14:13:43 UTC", 
+        "time": "2025-08-29T14:13:43.000", 
         "msg": "something went wrong"
     },
     {
         "eventType": "Request",
         "id": "6",
-        "time": "2025-08-05 14:14:04 UTC",
+        "time": "2025-08-29T14:14:04.000",
         "request": "example6 concurrent 1 case"
     },
     {
         "eventType": "Request",
         "id": "7",
-        "time": "2025-08-05 14:14:04 UTC",
+        "time": "2025-08-29T14:14:04.000",
         "request": "example7 concurrent 2 case"
     },
     {
         "eventType": "Response",
         "id": "7",
-        "time": "2025-08-05 14:14:05 UTC",
+        "time": "2025-08-29T14:14:05.000",
         "status": 202
     },
     {
         "eventType": "Response",
         "id": "6",
-        "time": "2025-08-05 14:14:05 UTC",
+        "time": "2025-08-29T14:14:05.000",
         "status": 202
     },
     {
         "eventType": "Request",
         "id": "8",
-        "time": "2025-08-05 14:15:03 UTC",
+        "time": "2025-08-29T14:15:03.000",
         "request": "example8 concurrent 3 case"
     },
     {
         "eventType": "Response",
         "id": "8",
-        "time": "2025-08-05 14:15:04 UTC",
+        "time": "2025-08-29T14:15:04.000",
         "status": 202
     },
     {
         "eventType": "Request",
         "id": "9",
-        "time": "2025-08-05 14:15:32 UTC",
+        "time": "2025-08-29T14:15:32.000",
         "request": "example9 concurrent 4 case"
     },
     {
         "eventType": "Response",
         "id": "9",
-        "time": "2025-08-05 14:15:33 UTC",
+        "time": "2025-08-29T14:15:33.000",
         "status": 202
     },
     {
     	"eventType": "Success",
         "id": "6",
-        "time": "2025-08-05 14:16:05 UTC",
+        "time": "2025-08-29T14:16:05.000",
         "duration": 121
     },
     {
     	"eventType": "Success",
         "id": "7",
-        "time": "2025-08-05 14:16:10 UTC",
+        "time": "2025-08-29T14:16:10.000",
         "duration": 126
     },
     {
     	"eventType": "Success",
         "id": "8",
-        "time": "2025-08-05 14:17:00 UTC",
+        "time": "2025-08-29T14:17:00.000",
         "duration": 117
     },
     {
     	"eventType": "Success",
         "id": "9",
-        "time": "2025-08-05 14:17:20 UTC",
+        "time": "2025-08-29T14:17:20.000",
         "duration": 108
     },
     {
     	"eventType": "Request",
         "id": "10",
-        "time": "2025-08-05 14:59:32 UTC",
+        "time": "2025-08-29T14:59:32.000",
         "request": "example10 ongoing case"
     }
 

--- a/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
+++ b/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
@@ -2,9 +2,17 @@ package latis.logviz
 
 import cats.effect.IO
 import cats.syntax.all.*
+import fs2.Stream
+import fs2.data.json.ast
+import fs2.data.json.circe.*
+import fs2.data.text.utf8.byteStreamCharLike
+import fs2.io.readClassLoaderResource
+import io.circe.Json
 import org.http4s.HttpRoutes
 import org.http4s.StaticFile
 import org.http4s.dsl.Http4sDsl
+
+import latis.logviz.model.Event
 
 /** 
  * Defines Routes
@@ -13,6 +21,7 @@ import org.http4s.dsl.Http4sDsl
  * - GET / (index.html)
  * - GET /main.js
  * - GET /events.json 
+ * - GET /events
  * 
  * Get each file from the resources folder, else return notFound
 */
@@ -30,6 +39,28 @@ object LogvizRoutes extends Http4sDsl[IO] {
     case req @ GET -> Root / "styles.css" =>
       StaticFile.fromResource("styles.css", req.some).getOrElseF(NotFound())
 
-    
+    case req @ GET -> Root / "events" =>
+      // getting the contents of the file
+      val rawtext: Stream[IO, Byte] = readClassLoaderResource[IO]("events.json")
+
+      // transforming to a stream of json
+      val rawjson: Stream[IO, Json] = rawtext.through(ast.parse)
+
+      val parsedJson: Stream[IO, Event] = rawjson.flatMap { fulljson =>
+        // separating the full json into json objects for each event
+        val decodedResult = fulljson.hcursor.as[List[Json]]
+      
+        // parse into Events
+        decodedResult match {
+          case Right(jsonList) => 
+            val events: List[Event] = jsonList.map(_.as[Event].toOption.get) // mapping to Event type
+            println(events)
+            Stream.emits(events).covary[IO]
+          case Left(error) =>
+            Stream.raiseError[IO](new Exception(s"Error parsing events.json into event stream with error: $error"))
+        }
+      }
+
+      Ok(parsedJson)
   }
 }

--- a/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
+++ b/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
@@ -69,7 +69,6 @@ object LogvizRoutes extends Http4sDsl[IO] {
           decodedResult match {
             case Right(jsonList) => 
               val events: List[Event] = jsonList.map(_.as[Event].toOption.get) // mapping to Event type
-              println(events)
               Stream.emits(events).covary[IO]
             case Left(error) =>
               Stream.raiseError[IO](new Exception(s"Error parsing events.json into event stream with error: $error"))

--- a/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
+++ b/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
@@ -55,7 +55,15 @@ object LogvizRoutes extends Http4sDsl[IO] {
 
         runSC.use { sclient =>
           val eventStream: Stream[IO, Event] = sclient.query()
-          Ok(eventStream)
+
+          // checking how much is coming through the stream
+
+          //
+          Ok(
+            "Testing..."
+          )
+
+          //Ok(eventStream)
         }
       else 
         // getting events from events.json

--- a/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
+++ b/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
@@ -56,14 +56,12 @@ object LogvizRoutes extends Http4sDsl[IO] {
         runSC.use { sclient =>
           val eventStream: Stream[IO, Event] = sclient.query()
 
-          // checking how much is coming through the stream
+          // counting the amount of events that were matched
+          val count: IO[Unit] = eventStream.compile.count.flatMap { count =>
+            IO.println(s"Processed $count events...")
+          }
 
-          //
-          Ok(
-            "Testing..."
-          )
-
-          //Ok(eventStream)
+          count *> Ok(eventStream)
         }
       else 
         // getting events from events.json

--- a/modules/frontend/src/main/scala/latis/logviz/EventClient.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventClient.scala
@@ -4,9 +4,11 @@ import cats.effect.IO
 import cats.syntax.all.*
 import fs2.Stream
 import fs2.dom.Window
-import org.http4s.EntityDecoder
+import io.circe.parser.*
+import org.http4s.Method
+import org.http4s.Request
+import org.http4s.ServerSentEvent
 import org.http4s.Uri
-import org.http4s.circe.jsonOf
 import org.http4s.client.Client
 
 import latis.logviz.model.Event
@@ -36,11 +38,67 @@ object EventClient {
     ).mapN { (protocol, host) =>
       val baseUri = Uri.unsafeFromString(s"$protocol//$host")
 
-      given eventDecoder: EntityDecoder[IO, List[Event]] = jsonOf
-
       new EventClient {
         override def getEvents: Stream[IO, Event] =
-          Stream.evals(http.expect[List[Event]](baseUri / "events"))
+          val request = Request[IO](method = Method.GET, uri = baseUri / "events")
+          
+          http.stream(request).flatMap{ res =>
+            res.body
+              .through(ServerSentEvent.decoder[IO]) // Pipe[IO, Byte, SSE]
+              .map{
+                case ServerSentEvent(None, None, None, None, None) => None
+                case sse => 
+                  sse.data match {
+                  case Some(event) => 
+                    parse(event) match {
+                    case Right(json) => json.as[Event] match {
+                      case Right(event) => Some(event)
+                      case Left(error) => throw new Exception(s"Error parsing json to event with error $error")
+                    }
+                    case Left(error) => throw new Exception(s"Error parsing server sent event to json with error $error")
+                  }
+                  case None => throw new Exception(s"Server sent event missing data field")
+                }
+              }
+              .collect{case Some(event) => event} // getting rid of the None SSE
+          }
       }
     }
+}
+
+def serverSentToEvent(event: ServerSentEvent): Event = {
+  val line: Array[String] = event.data match {
+    case Some(data) => 
+      data.split("time: ")
+    case None => 
+      throw new Exception("Server sent event missing data field")
+  }
+
+  event.eventType match {
+    case Some("Start") =>
+      val time: String = line(1)
+      Event.Start(time)
+    case Some("Request") => 
+      val id: String = line(0).split("id: ")(1).dropRight(1)
+      val time: String = line(1).split("request: ")(0).dropRight(1)
+      val request: String = line(1).split("request: ")(1)
+      Event.Request(id, time, request)
+    case Some("Response") =>
+      val id: String = line(0).split("id: ")(1).dropRight(1)
+      val time: String = line(1).split("status: ")(0).dropRight(1)
+      val status: Int = line(1).split("status: ")(1).toInt
+      Event.Response(id, time, status)
+    case Some("Success") =>
+      val id: String = line(0).split("id: ")(1).dropRight(1)
+      val time: String = line(1).split("duration: ")(0).dropRight(1)
+      val duration: Long = line(1).split("duration: ")(1).toLong
+      Event.Success(id, time, duration)
+    case Some("Failure") =>
+      val id: String = line(0).split("id: ")(1).dropRight(1)
+      val time: String = line(1).split("msg: ")(0).dropRight(1)
+      val msg: String = line(1).split("msg: ")(1)
+      Event.Failure(id, time, msg)
+    case Some(_) => throw new Exception("Error parsing server sent event to event")
+    case None => throw new Exception("Error parsing server sent event to event")
+  }
 }

--- a/modules/frontend/src/main/scala/latis/logviz/EventClient.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventClient.scala
@@ -40,7 +40,7 @@ object EventClient {
 
       new EventClient {
         override def getEvents: Stream[IO, Event] =
-          Stream.evals(http.expect[List[Event]](baseUri / "events.json"))
+          Stream.evals(http.expect[List[Event]](baseUri / "events"))
       }
     }
 }

--- a/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
@@ -1,6 +1,7 @@
 package latis.logviz
 
-import java.time.ZonedDateTime
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.time.format.DateTimeFormatter
 
@@ -29,7 +30,7 @@ import latis.logviz.model.Rectangle
   * @param requestDetails div for hover feature
   */
 class EventComponent(stream: Stream[IO, Event], requestDetails: HtmlElement[IO]) {
-  val timestampFormatter= DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:00 VV")
+  val timestampFormatter= DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:00")
   val pixelsPerSec = 1.0
 
  
@@ -59,7 +60,7 @@ class EventComponent(stream: Stream[IO, Event], requestDetails: HtmlElement[IO])
    * Same as saying how far off we are from the top of canvas(current time)
    * [[https://www.geeksforgeeks.org/java/java-time-duration-class-in-java/#]]
   */
-  private def convertTime(timestamp: ZonedDateTime, current: ZonedDateTime): Double = 
+  private def convertTime(timestamp: LocalDateTime, current: LocalDateTime): Double = 
     java.time.Duration.between(timestamp, current).toSeconds() * pixelsPerSec
 
   /**
@@ -82,8 +83,8 @@ class EventComponent(stream: Stream[IO, Event], requestDetails: HtmlElement[IO])
    * @param width total available space for columns to be drawn
   */
   private def drawCanvas(
-    current: ZonedDateTime,
-    endTime: ZonedDateTime,
+    current: LocalDateTime,
+    endTime: LocalDateTime,
     canvas: HTMLCanvasElement,
     context: dom.CanvasRenderingContext2D,
     rects: List[Rectangle],
@@ -129,14 +130,19 @@ class EventComponent(stream: Stream[IO, Event], requestDetails: HtmlElement[IO])
   ): IO[Unit] = IO {
     context.fillStyle = color
     context.fillRect(x, y, width, duration)
+
+    // put borders around events
+    if(color != "lightgray" && color != "white") then
+      context.strokeStyle = "black"
+      context.strokeRect(x, y, width, duration)
   }
   
   private def drawTS(
     context: dom.CanvasRenderingContext2D,
     y: Double,
-    timestamp: ZonedDateTime
+    timestamp: LocalDateTime
     ): IO[Unit] = IO {
-    context.font = ("helvectica")
+    context.font = ("helvetica")
     context.fillStyle = "black"
     context.fillText(timestamp.format(timestampFormatter), 0, y)}
 
@@ -179,8 +185,8 @@ class EventComponent(stream: Stream[IO, Event], requestDetails: HtmlElement[IO])
                         _       <- IO(canvas.width = tlRect.width.toInt)
                         _       <- IO(canvas.height = tlRect.height.toInt)
                         width   <- IO(canvas.width - 150)     // offset by 150 for total width of canvas that rectangles should cover
-                        now     <- IO(ZonedDateTime.now(java.time.ZoneId.of("UTC")))
-                        end     <- IO(now.toLocalDate.atStartOfDay(now.getZone()))
+                        now     <- IO(LocalDateTime.now(ZoneOffset.UTC))
+                        end     <- IO(now.toLocalDate.atStartOfDay())
                         _       <- IO(sizer.style.height = s"${convertTime(end, now)+2}px")
                         maxCol  <- parser.getMaxConcurrent()
                         // _       <-  makeRect(now, em.events, em.compEvents, em.rectangles, em.maxCounter, height, top, width)
@@ -232,7 +238,10 @@ class EventComponent(stream: Stream[IO, Event], requestDetails: HtmlElement[IO])
                     rects.traverse {
                       case Rectangle(event, x, y, width, height, color) => {
                         if (mouseX >= x && mouseX <= x + width && mouseY <= y && mouseY >= y + height) {
-                          IO(requestDetails.textContent = s"EVENT DETAILS: $event")
+                          IO{
+                            requestDetails.style.fontSize = "20px"
+                            requestDetails.textContent = s"EVENT DETAILS: $event"
+                          }
                         } else {
                           IO.unit
                         }

--- a/modules/frontend/src/main/scala/latis/logviz/Rectangles.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/Rectangles.scala
@@ -2,14 +2,14 @@ package latis.logviz
 
 import java.time.Duration
 import java.time.format.DateTimeFormatter
-import java.time.ZonedDateTime
+import java.time.LocalDateTime
 
 import latis.logviz.model.RequestEvent
 import latis.logviz.model.Rectangle
 
 
 object Rectangles{
-  val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss VV")
+  val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")
   val pixelsPerSec = 1.0
   val startOffset = 150
 
@@ -34,7 +34,7 @@ object Rectangles{
     * @return list of rectangles
     */
   def makeRectangles(
-    currTime: ZonedDateTime,
+    currTime: LocalDateTime,
     height: Double,
     top: Double,
     width: Int, 
@@ -44,7 +44,7 @@ object Rectangles{
     val rects: List[Rectangle] = events.foldLeft(List[Rectangle]()){ (acc, event) =>
         event match {
           case (RequestEvent.Server(time), cDepth) => 
-            val eventTime = ZonedDateTime.parse(time, formatter)
+            val eventTime = LocalDateTime.parse(time, formatter)
             val y = Duration.between(eventTime, currTime).toSeconds() * pixelsPerSec
 
             if (y >= top && y - 2 < bottomY) {
@@ -55,7 +55,7 @@ object Rectangles{
             }
 
           case (RequestEvent.Request(start, url), cDepth) =>
-            val eventTime = ZonedDateTime.parse(start, formatter)
+            val eventTime = LocalDateTime.parse(start, formatter)
             val y = Duration.between(eventTime, currTime).toSeconds() * pixelsPerSec
             if (y >= top) {
               Rectangle((RequestEvent.Request(start, url), cDepth),
@@ -65,8 +65,8 @@ object Rectangles{
             }
 
           case (RequestEvent.Success(start, url, end, duration), cDepth) =>
-            val eventTime = ZonedDateTime.parse(start, formatter)
-            val endTime = ZonedDateTime.parse(end, formatter)
+            val eventTime = LocalDateTime.parse(start, formatter)
+            val endTime = LocalDateTime.parse(end, formatter)
             val y = Duration.between(eventTime, currTime).toSeconds() * pixelsPerSec
             val y_end = Duration.between(endTime, currTime).toSeconds() * pixelsPerSec
 
@@ -78,8 +78,8 @@ object Rectangles{
             }
           
           case (RequestEvent.Failure(start, url, end, msg), cDepth) =>
-            val eventTime = ZonedDateTime.parse(start, formatter)
-            val endTime = ZonedDateTime.parse(end, formatter)
+            val eventTime = LocalDateTime.parse(start, formatter)
+            val endTime = LocalDateTime.parse(end, formatter)
             val y = Duration.between(eventTime, currTime).toSeconds() * pixelsPerSec
             val y_end = Duration.between(endTime, currTime).toSeconds() * pixelsPerSec
 

--- a/modules/shared/src/main/scala/latis/logviz/model/Event.scala
+++ b/modules/shared/src/main/scala/latis/logviz/model/Event.scala
@@ -94,7 +94,7 @@ object Event {
     }
   }
 
-  given Encoder[Event] = Encoder.instance { (event: Event) => event match
+  given Encoder[Event] = Encoder.instance {
     case Start(time) => 
       Json.obj("eventType" -> "Start".asJson, "time" -> time.asJson)
 

--- a/modules/shared/src/main/scala/latis/logviz/model/Event.scala
+++ b/modules/shared/src/main/scala/latis/logviz/model/Event.scala
@@ -1,8 +1,15 @@
 package latis.logviz.model
 
+import cats.effect.IO
 import cats.syntax.all.*
+import fs2.Stream
 import io.circe.Decoder
 import io.circe.DecodingFailure
+import io.circe.Encoder
+import io.circe.Json
+import io.circe.syntax.*
+import org.http4s.EntityEncoder
+import org.http4s.circe.*
 
 
 /**
@@ -86,4 +93,23 @@ object Event {
       case typ => DecodingFailure(s"Unknown event type: $typ", ev.history).asLeft
     }
   }
+
+  given Encoder[Event] = Encoder.instance { (event: Event) => event match
+    case Start(time) => 
+      Json.obj("eventType" -> "Start".asJson, "time" -> time.asJson)
+
+    case Request(id, time, request) =>
+      Json.obj("eventType" -> "Request".asJson, "id" -> id.asJson, "time" -> time.asJson, "request" -> request.asJson)
+
+    case Response(id, time, status) =>
+      Json.obj("eventType" -> "Response".asJson, "id" -> id.asJson, "time" -> time.asJson, "status" -> status.asJson)
+
+    case Success(id, time, duration) =>
+      Json.obj("eventType" -> "Success".asJson, "id" -> id.asJson, "time" -> time.asJson, "duration" -> duration.asJson)
+
+    case Failure(id, time, msg) =>
+      Json.obj("eventType" -> "Failure".asJson, "id" -> id.asJson, "time" -> time.asJson, "message" -> msg.asJson)
+  }
+
+  given EntityEncoder[IO, Stream[IO, Event]] = streamJsonArrayEncoderOf[IO, Event]
 }

--- a/modules/splunk/src/main/resources/application.conf
+++ b/modules/splunk/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 logviz.splunk {
-  enabled = true
+  enabled = false
 
   uri = ${LOGVIZ_SPLUNK_URI}
   username = ${LOGVIZ_SPLUNK_USERNAME}

--- a/modules/splunk/src/main/resources/application.conf
+++ b/modules/splunk/src/main/resources/application.conf
@@ -1,5 +1,7 @@
 logviz.splunk {
-  uri = ${LOGIVZ_SPLUNK_URI}
+  enabled = true
+
+  uri = ${LOGVIZ_SPLUNK_URI}
   username = ${LOGVIZ_SPLUNK_USERNAME}
   password = ${LOGVIZ_SPLUNK_PASSWORD}
 }

--- a/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkClient.scala
+++ b/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkClient.scala
@@ -146,12 +146,12 @@ object SplunkClient {
               else if line.contains("Ember-Server service bound to address:") then
                 val time = line.split(" INFO")(0).drop(1)
                 Some(Event.Start(time))
-              else if line.contains("Request failed") then
-                val spl = line.split(" ERROR")
-                val id = "unknown"
-                val time = spl(0).drop(1)
-                val msg = "unknown"
-                Some(Event.Failure(id, time, msg))
+              // else if line.contains("Request failed") then
+              //   val spl = line.split(" ERROR")
+              //   val id = "unknown"
+              //   val time = spl(0).drop(1)
+              //   val msg = "unknown"
+              //   Some(Event.Failure(id, time, msg))
               else
                 None
             }
@@ -163,7 +163,7 @@ object SplunkClient {
 
           def query(/* takes args in the future */): Stream[IO, Event] = {
             // make the query from args
-            val query = "search index=latis source=latis3-swp* earliest_time=-24h@h latest_time=now"
+            val query = "search index=latis source=latis3-swp* earliest_time=-24h@h latest_time=now | reverse"
 
             Stream.eval {
               for {

--- a/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkConfig.scala
+++ b/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkConfig.scala
@@ -1,11 +1,30 @@
 package latis.logviz.splunk
 
+import cats.syntax.all.*
 import org.http4s.Uri
 import pureconfig.ConfigReader
 import pureconfig.module.http4s.*
 
-case class SplunkConfig(
-  uri: Uri,
-  username: String,
-  password: String
-) derives ConfigReader
+enum SplunkConfig {
+  case Disabled
+  case Enabled(
+    uri: Uri,
+    username: String,
+    password: String
+  )
+}
+
+object SplunkConfig {
+  given ConfigReader[SplunkConfig] = ConfigReader.fromCursor { c =>
+    c.asObjectCursor.flatMap { c => 
+      c.atKey("enabled").flatMap(_.asBoolean).flatMap {
+        case false => SplunkConfig.Disabled.pure[ConfigReader.Result]
+        case true => (
+          c.atKey("uri").flatMap(ConfigReader[Uri].from),
+          c.atKey("username").flatMap(_.asString),
+          c.atKey("password").flatMap(_.asString)
+        ).mapN(SplunkConfig.Enabled.apply)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Returning server sent events from the streams by optionally configuring either Splunk or the JSON file. Added a function to map events to server sent events and return those to http4s with the correct header. 

Consuming server sent events takes in the stream and uses the pre-existing JSON decoder to parse them back into Events. I added borders around the events so that across multiple columns of simultaneous events it is not one green block.