### PR TITLE
Adding instance endpoint

### DIFF
--- a/modules/app/src/main/scala/latis/logviz/Main.scala
+++ b/modules/app/src/main/scala/latis/logviz/Main.scala
@@ -20,7 +20,7 @@ import latis.logviz.splunk.*
  * ShutdownTimeout of 5 seconds forcefully shuts down server in 5 seconds after stopping app
 */
 object Main extends IOApp.Simple {
-  val eventSource: Resource[IO, EventSource] = for {
+  val eventSource: Resource[IO, EventSource with InstanceSource] = for {
     splunkConf <- Resource.eval(ConfigSource.default.at("logviz.splunk").loadF[IO, SplunkConfig]())
     source     <- splunkConf match {
       case SplunkConfig.Disabled => Resource.pure[IO, JSONEventSource](JSONEventSource())

--- a/modules/app/src/main/scala/latis/logviz/Main.scala
+++ b/modules/app/src/main/scala/latis/logviz/Main.scala
@@ -20,20 +20,20 @@ import latis.logviz.splunk.*
  * ShutdownTimeout of 5 seconds forcefully shuts down server in 5 seconds after stopping app
 */
 object Main extends IOApp.Simple {
-  val eventSource: Resource[IO, EventSource with InstanceSource] = for {
+  val eventSource: Resource[IO, (EventSource, InstanceSource)] = for {
     splunkConf <- Resource.eval(ConfigSource.default.at("logviz.splunk").loadF[IO, SplunkConfig]())
     source     <- splunkConf match {
       case SplunkConfig.Disabled => Resource.pure[IO, JSONEventSource](JSONEventSource())
       case SplunkConfig.Enabled(uri, username, password, source, index) => SplunkClient.make(uri, username, password).map(client => SplunkEventSource(client, source, index))
     }
-  } yield source
+  } yield (source, source)
 
   override def run: IO[Unit] =
     eventSource.use { es =>
       EmberServerBuilder
         .default[IO]
         .withHost(ipv4"0.0.0.0")
-        .withHttpApp(LogvizRoutes(es).routes.orNotFound)
+        .withHttpApp(LogvizRoutes(es._1, es._2).routes.orNotFound)
         .withShutdownTimeout(5.seconds)
         .build
         .useForever

--- a/modules/backend/src/main/scala/latis/logviz/InstanceSource.scala
+++ b/modules/backend/src/main/scala/latis/logviz/InstanceSource.scala
@@ -1,0 +1,9 @@
+package latis.logviz
+
+import cats.effect.IO
+
+/** Describes an instance source that events come from */
+trait InstanceSource {
+  /** Gets events from a given instance */
+  def instances: IO[List[(String, Long)]]
+}

--- a/modules/backend/src/main/scala/latis/logviz/InstanceSource.scala
+++ b/modules/backend/src/main/scala/latis/logviz/InstanceSource.scala
@@ -2,8 +2,8 @@ package latis.logviz
 
 import cats.effect.IO
 
-/** Describes an instance source that events come from */
+/** Describes an instance source that can enumerate LaTiS instances */
 trait InstanceSource {
-  /** Gets events from a given instance */
-  def instances: IO[List[(String, Long)]]
+  /** Enumerates LaTiS instances */
+  def instances: IO[List[String]]
 }

--- a/modules/backend/src/main/scala/latis/logviz/JSONEventSource.scala
+++ b/modules/backend/src/main/scala/latis/logviz/JSONEventSource.scala
@@ -87,8 +87,8 @@ class JSONEventSource extends EventSource with InstanceSource {
             }
       }
 
-  override def instances: IO[List[(String, Long)]] = {
-    IO {List(("json", 0))}
+  override def instances: IO[List[String]] = {
+    IO.pure(List("json"))
   }
 }
 

--- a/modules/backend/src/main/scala/latis/logviz/JSONEventSource.scala
+++ b/modules/backend/src/main/scala/latis/logviz/JSONEventSource.scala
@@ -23,7 +23,7 @@ val formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm
 /**
   * Test event source. Pulling dummy data from a test JSON file
   */
-class JSONEventSource extends EventSource {
+class JSONEventSource extends EventSource with InstanceSource {
   override def getEvents(start: LocalDateTime, end: LocalDateTime): Stream[IO, Event] =
 
     val byteStream: Stream[IO, Byte] = readClassLoaderResource[IO]("events.json")
@@ -86,6 +86,10 @@ class JSONEventSource extends EventSource {
               }
             }
       }
+
+  override def instances: IO[List[(String, Long)]] = {
+    IO {List(("json", 0))}
+  }
 }
 
 private def getEventTime(event: Event): LocalDateTime = 

--- a/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
+++ b/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
@@ -26,7 +26,7 @@ import latis.logviz.model.Event
  * 
  * Get each file from the resources folder, else return notFound
 */
-class LogvizRoutes(eventsource: EventSource with InstanceSource) extends Http4sDsl[IO] {
+class LogvizRoutes(eventsource: EventSource, instancesource: InstanceSource) extends Http4sDsl[IO] {
   def routes: HttpRoutes[IO] = HttpRoutes.of[IO] {
     case req @ GET -> Root =>
       StaticFile.fromResource("index.html", req.some).getOrElseF(NotFound())
@@ -50,7 +50,7 @@ class LogvizRoutes(eventsource: EventSource with InstanceSource) extends Http4sD
       Ok(sse)
 
     case req @ GET -> Root / "instances" =>
-      val list = eventsource.instances.map { tup =>
+      val list = instancesource.instances.map { tup =>
         tup.asJson
       }
 

--- a/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
+++ b/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
@@ -6,6 +6,7 @@ import java.time.ZoneOffset
 import cats.effect.IO
 import cats.syntax.all.*
 import io.circe.syntax.*
+import org.http4s.circe.*
 import org.http4s.EventStream
 import org.http4s.HttpRoutes
 import org.http4s.ServerSentEvent
@@ -25,7 +26,7 @@ import latis.logviz.model.Event
  * 
  * Get each file from the resources folder, else return notFound
 */
-class LogvizRoutes(eventsource: EventSource) extends Http4sDsl[IO] {
+class LogvizRoutes(eventsource: EventSource with InstanceSource) extends Http4sDsl[IO] {
   def routes: HttpRoutes[IO] = HttpRoutes.of[IO] {
     case req @ GET -> Root =>
       StaticFile.fromResource("index.html", req.some).getOrElseF(NotFound())
@@ -47,6 +48,13 @@ class LogvizRoutes(eventsource: EventSource) extends Http4sDsl[IO] {
       val sse: EventStream[IO] = events.map(eventToServerSent)
 
       Ok(sse)
+
+    case req @ GET -> Root / "instances" =>
+      val list = eventsource.instances.map { tup =>
+        tup.asJson
+      }
+
+      Ok(list)
   }
 
   private def eventToServerSent(event: Event): ServerSentEvent = {

--- a/modules/backend/src/main/scala/latis/logviz/SplunkEventSource.scala
+++ b/modules/backend/src/main/scala/latis/logviz/SplunkEventSource.scala
@@ -13,8 +13,12 @@ import latis.logviz.splunk.*
  * @constructor create a new splunk source with a splunk client
  * @param sclient the SplunkClient used to access splunk
  */
-class SplunkEventSource(sclient: SplunkClient, source: String, index: String) extends EventSource {
+class SplunkEventSource(sclient: SplunkClient, source: String, index: String) extends EventSource with InstanceSource {
   override def getEvents(start: LocalDateTime, end: LocalDateTime): Stream[IO, Event] = {
     sclient.query(start, end, source, index)
+  }
+
+  override def instances: IO[List[(String, Long)]] = {
+    sclient.enumerateSources
   }
 }

--- a/modules/backend/src/main/scala/latis/logviz/SplunkEventSource.scala
+++ b/modules/backend/src/main/scala/latis/logviz/SplunkEventSource.scala
@@ -18,7 +18,7 @@ class SplunkEventSource(sclient: SplunkClient, source: String, index: String) ex
     sclient.query(start, end, source, index)
   }
 
-  override def instances: IO[List[(String, Long)]] = {
-    sclient.enumerateSources
+  override def instances: IO[List[String]] = {
+    sclient.enumerateSources.map(_.map(_._1))
   }
 }


### PR DESCRIPTION
Added an `InstanceSource` trait that `JSONEventSource` and `SplunkEventSource` extend, which LogvizRoutes uses when creating an event source client. The /instances endpoint shows a JSON array of instance name and most recent time an event had that instance, where the JSON event source has ("json", 0).