### PR TITLE
LATIS 1243: Instance Selection

### DIFF
--- a/modules/backend/src/main/resources/events.json
+++ b/modules/backend/src/main/resources/events.json
@@ -24,7 +24,7 @@
         "status": 202
     },
     {
-        "eventType":"Success",
+        "eventType": "Success",
         "id": "11",
         "time": "-60830000",
         "duration": 70
@@ -44,7 +44,7 @@
     {
         "eventType": "Response",
         "id": "12",
-        "time":"-57304995",
+        "time": "-57304995",
         "status": 202
     },
     {
@@ -52,7 +52,6 @@
         "id": "12",
         "time": "-56700000",
         "duration": 605
-        
     },
     {
         "eventType": "Start",
@@ -95,53 +94,49 @@
         "msg": "overlapping test red!"
     },
     {
-       	"eventType": "Request",
-      	"id": "2",
-      	"time": "-51894000",
-	    "request": "bad request example"	
+        "eventType": "Request",
+        "id": "2",
+        "time": "-51894000",
+        "request": "bad request example"
     },
     {
-    	"eventType": "Response",
+        "eventType": "Response",
         "id": "2",
         "time": "-51893000",
         "status": 404
     },
-    { 
+    {
         "eventType": "Request",
         "id": "3",
         "time": "-26880000",
         "request": "example3"
-    
-    }, 
+    },
     {
-    	"eventType": "Response",
+        "eventType": "Response",
         "id": "3",
         "time": "-26879000",
         "status": 202
-    
     },
-    {	
+    {
         "eventType": "Request",
         "id": "4",
         "time": "-26877000",
         "request": "example4"
-    
-    }, 
+    },
     {
-    	"eventType": "Response",
+        "eventType": "Response",
         "id": "4",
         "time": "-26876000",
         "status": 202
-    
     },
     {
-    	"eventType": "Success",
+        "eventType": "Success",
         "id": "4",
         "time": "-26865000",
         "duration": 12
     },
     {
-    	"eventType": "Success",
+        "eventType": "Success",
         "id": "3",
         "time": "-26800000",
         "duration": 80
@@ -151,19 +146,17 @@
         "id": "5",
         "time": "-24600000",
         "request": "example5 fail case"
-    
-    }, 
+    },
     {
-    	"eventType": "Response",
+        "eventType": "Response",
         "id": "5",
         "time": "-24599000",
         "status": 202
-        
     },
     {
         "eventType": "Failure",
         "id": "5",
-        "time": "-24597000", 
+        "time": "-24597000",
         "msg": "something went wrong"
     },
     {
@@ -215,109 +208,109 @@
         "status": 202
     },
     {
-    	"eventType": "Success",
+        "eventType": "Success",
         "id": "6",
         "time": "-18238000",
         "duration": 121
     },
     {
-    	"eventType": "Success",
+        "eventType": "Success",
         "id": "7",
         "time": "-18234000",
         "duration": 126
     },
     {
-    	"eventType": "Success",
+        "eventType": "Success",
         "id": "8",
         "time": "-18183000",
         "duration": 117
     },
     {
-    	"eventType": "Success",
+        "eventType": "Success",
         "id": "9",
         "time": "-18178000",
         "duration": 108
     },
     {
-    	"eventType": "Request",
+        "eventType": "Request",
         "id": "10",
         "time": "-1786000",
         "request": "example10 ongoing case"
     },
     {
-    	"eventType": "Request",
+        "eventType": "Request",
         "id": "14",
         "time": "5674",
         "request": "example 11 future event"
     },
     {
-    	"eventType": "Response",
+        "eventType": "Response",
         "id": "14",
         "time": "5678",
         "status": 202
     },
     {
-    	"eventType": "Success",
+        "eventType": "Success",
         "id": "14",
         "time": "205674",
         "duration": 200
     },
     {
-    	"eventType": "Request",
+        "eventType": "Request",
         "id": "15",
         "time": "1200000",
         "request": "example 15 future failed event"
     },
     {
-    	"eventType": "Response",
+        "eventType": "Response",
         "id": "15",
         "time": "1202000",
         "status": 404
     },
     {
-    	"eventType": "Request",
+        "eventType": "Request",
         "id": "16",
         "time": "2700000",
         "request": "example 16 future concurrent event"
     },
     {
-    	"eventType": "Response",
+        "eventType": "Response",
         "id": "16",
         "time": "2701000",
         "status": 202
     },
     {
-    	"eventType": "Request",
+        "eventType": "Request",
         "id": "17",
         "time": "2720000",
         "request": "example 17 future failed concurrent event"
     },
     {
-    	"eventType": "Request",
+        "eventType": "Request",
         "id": "18",
         "time": "2720000",
         "request": "example 18 future concurrent event"
     },
     {
-    	"eventType": "Response",
+        "eventType": "Response",
         "id": "17",
         "time": "2721000",
         "status": 202
     },
     {
-    	"eventType": "Response",
+        "eventType": "Response",
         "id": "18",
         "time": "2721000",
         "status": 202
     },
     {
-    	"eventType": "Success",
+        "eventType": "Success",
         "id": "16",
         "time": "2880000",
         "duration": 180
     },
     {
-    	"eventType": "Success",
+        "eventType": "Success",
         "id": "18",
         "time": "2910000",
         "duration": 190
@@ -325,11 +318,7 @@
     {
         "eventType": "Failure",
         "id": "17",
-        "time": "2930000", 
+        "time": "2930000",
         "msg": "failed future event!"
     }
-
-
-
-
 ]

--- a/modules/backend/src/main/resources/events1.json
+++ b/modules/backend/src/main/resources/events1.json
@@ -1,0 +1,114 @@
+[
+  {
+    "eventType": "Request",
+    "id": "6",
+    "time": "-500000",
+    "request": "past success event"
+  },
+  {
+    "eventType": "Response",
+    "id": "6",
+    "time": "-499999",
+    "status": 202
+  },
+  {
+    "eventType": "Success",
+    "id": "6",
+    "time": "-320000",
+    "duration": 180
+  },
+  {
+    "eventType": "Start",
+    "time": "0"
+  },
+  {
+    "eventType": "Request",
+    "id": "0",
+    "time": "5000",
+    "request": "future success event"
+  },
+  {
+    "eventType": "Response",
+    "id": "0",
+    "time": "6000",
+    "status": 202
+  },
+  {
+    "eventType": "Success",
+    "id": "0",
+    "time": "200000",
+    "duration": 195
+  },
+  {
+    "eventType": "Request",
+    "id": "1",
+    "time": "400000",
+    "request": "future failed event"
+  },
+  {
+    "eventType": "Response",
+    "id": "1",
+    "time": "401000",
+    "status": 202
+  },
+  {
+    "eventType": "Failure",
+    "id": "1",
+    "time": "500000",
+    "msg": "future failed event"
+  },
+  {
+    "eventType": "Request",
+    "id": "2",
+    "time": "800000",
+    "request": "future failed response"
+  },
+  {
+    "eventType": "Response",
+    "id": "2",
+    "time": "801000",
+    "status": 404
+  },
+  {
+    "eventType": "Request",
+    "id": "3",
+    "time": "1200000",
+    "request": "first future concurrent event"
+  },
+  {
+    "eventType": "Request",
+    "id": "4",
+    "time": "1200000",
+    "request": "second future concurrent event"
+  },
+  {
+    "eventType": "Response",
+    "id": "3",
+    "time": "1201000",
+    "status": 202
+  },
+  {
+    "eventType": "Response",
+    "id": "4",
+    "time": "1201000",
+    "status": 202
+  },
+  {
+    "eventType": "Success",
+    "id": "3",
+    "time": "1400000",
+    "duration": 200
+  },
+  {
+    "eventType": "Success",
+    "id": "4",
+    "time": "1410000",
+    "duration": 210
+  },
+  {
+    "eventType": "Request",
+    "id": "5",
+    "time": "1800000",
+    "request": "future ongoing"
+  }
+]

--- a/modules/backend/src/main/resources/styles.css
+++ b/modules/backend/src/main/resources/styles.css
@@ -1,92 +1,84 @@
-#container
-{
-    display: flex;
-    flex-direction: column;
+#container {
+  display: flex;
+  flex-direction: column;
 }
 
 #box {
-    display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    grid-auto-rows: 150px;
-    height: 100%;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-auto-rows: 150px;
+  height: 100%;
 }
 
-#timeline
-{
-    grid-column: span 5;
-    grid-row: span 5;
-    overflow: auto;
-}   
-
-#request-detail
-{
-    grid-row: 6;
-    grid-column: span 3;
-    padding-top: 10px;
-    padding-left: 5px;
+#timeline {
+  grid-column: span 5;
+  grid-row: span 5;
+  overflow: auto;
 }
 
-#time-selection
-{
-    grid-row: 6;
-    grid-column: 4;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding-top: 10px;
+#request-detail {
+  grid-row: 6;
+  grid-column: span 2;
+  padding-top: 10px;
+  padding-left: 5px;
 }
 
-#canvas
-{
-    height: 100%;
-    width: 100%;
-    position: sticky;
-    top: 0;
+#time-selection {
+  grid-row: 6;
+  grid-column: 4;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 10px;
 }
 
-input:invalid + span::after {
+#canvas {
+  height: 100%;
+  width: 100%;
+  position: sticky;
+  top: 0;
+}
+
+input:invalid+span::after {
   content: "✖";
   padding-left: 5px;
 }
 
-input:valid + span::after {
+input:valid+span::after {
   content: "✓";
   padding-left: 5px;
 }
 
 #start-time {
-  display:flex;
-  align-items: center;
-}
-
-#end-time{
   display: flex;
   align-items: center;
 }
 
-#time-range{
+#end-time {
+  display: flex;
+  align-items: center;
+}
+
+#time-range {
   display: flex;
   align-items: center;
   padding: 5px;
 }
 
-.request-detail-list
-{
-    display: grid;
-    grid-template-columns: auto 1fr;
+.request-detail-list {
+  display: grid;
+  grid-template-columns: auto 1fr;
 }
 
-.request-detail-key
-{
-    font-weight: bold;
+.request-detail-key {
+  font-weight: bold;
 }
 
-.request-detail-key::after
-{
+.request-detail-key::after {
   content: ':';
 }
 
-#zoom{
+#zoom {
   grid-row: 6;
   grid-column: 5;
   padding-top: 10px;
@@ -95,13 +87,41 @@ input:valid + span::after {
   align-items: center;
 }
 
-.zoom-button{
+.zoom-button {
   font-weight: bold;
   font-size: 15px;
   border: none;
   background-color: transparent;
 }
 
-.zoom-button:hover{
+.zoom-button:hover {
   background-color: grey;
+}
+
+.autocomplete {
+  padding-top: 10px;
+}
+
+#instance {
+  width: 100%;
+}
+
+.autocomplete-panel {
+  max-height: 150px;
+  overflow-y: auto;
+  box-shadow: 2px 8px 15px -15px;
+}
+
+.instance-list {
+  list-style: none;
+  margin: 0;
+  padding: 3px 0px;
+}
+
+.dropdown-item {
+  padding: 10px;
+}
+
+.dropdown-item:hover {
+  background: lightgrey
 }

--- a/modules/backend/src/main/scala/latis/logviz/EventSource.scala
+++ b/modules/backend/src/main/scala/latis/logviz/EventSource.scala
@@ -15,5 +15,5 @@ trait EventSource {
     * @param end the end time used to filter for events
     * @return a stream of events that have been parsed into Event objects
     */
-  def getEvents(start: LocalDateTime, end: LocalDateTime): Stream[IO, Event]
+  def getEvents(start: LocalDateTime, end: LocalDateTime, instance: Option[String]): Stream[IO, Event]
 }

--- a/modules/backend/src/main/scala/latis/logviz/JSONEventSource.scala
+++ b/modules/backend/src/main/scala/latis/logviz/JSONEventSource.scala
@@ -24,7 +24,7 @@ val formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm
   * Test event source. Pulling dummy data from a test JSON file
   */
 class JSONEventSource extends EventSource with InstanceSource {
-  override def getEvents(start: LocalDateTime, end: LocalDateTime): Stream[IO, Event] =
+  override def getEvents(start: LocalDateTime, end: LocalDateTime, instance: Option[String]): Stream[IO, Event] =
 
     val byteStream: Stream[IO, Byte] = readClassLoaderResource[IO]("events.json")
     

--- a/modules/backend/src/main/scala/latis/logviz/JSONEventSource.scala
+++ b/modules/backend/src/main/scala/latis/logviz/JSONEventSource.scala
@@ -24,9 +24,18 @@ val formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm
   * Test event source. Pulling dummy data from a test JSON file
   */
 class JSONEventSource extends EventSource with InstanceSource {
-  override def getEvents(start: LocalDateTime, end: LocalDateTime): Stream[IO, Event] =
+  override def getEvents(start: LocalDateTime, end: LocalDateTime, instance: Option[String]): Stream[IO, Event] =
 
-    val byteStream: Stream[IO, Byte] = readClassLoaderResource[IO]("events.json")
+    //TODO:
+    //BUG: seems like as soon as I don't have any future events, I start having a chunked encoding error
+    val instanceName = instance match {
+      case Some("json") => "events.json"
+      case Some("json1") => "events1.json" 
+      case _ => "events.json"
+
+    }
+    
+    val byteStream: Stream[IO, Byte] = readClassLoaderResource[IO](instanceName)
     
     val decodedJson: Stream[IO, List[Event]] = byteStream
       .through(ast.parse)
@@ -59,7 +68,6 @@ class JSONEventSource extends EventSource with InstanceSource {
 
           //not sure whether to calculate future events based on end time or curr time
           //in real practice, if this was "real" data, then future events should probably based on current time to actually be future events
-          //
           val curr = LocalDateTime.now(ZoneOffset.UTC)
           Stream.eval(Queue.unbounded[IO, Option[Event]]).flatMap{ queue => 
               Stream.eval(past.traverse{e => 
@@ -93,7 +101,7 @@ class JSONEventSource extends EventSource with InstanceSource {
       }
 
   override def instances: IO[List[String]] = {
-    IO.pure(List("json"))
+    IO.pure(List("json", "json1"))
   }
 }
 

--- a/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
+++ b/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
@@ -43,7 +43,10 @@ class LogvizRoutes(eventsource: EventSource, instancesource: InstanceSource) ext
       StaticFile.fromResource("styles.css", req.some).getOrElseF(NotFound())
 
     // event with query params
-    case req @ GET -> Root / "events" :? StartDateQueryParamMatcher(startTime) +& EndDateQueryParamMatcher(endTime) =>
+    case req @ GET -> Root / "events" :? 
+    StartDateQueryParamMatcher(startTime) +&
+    EndDateQueryParamMatcher(endTime) +&
+    InstanceQueryParamMatcher(instance) =>
 
       val start = startTime.toEither.leftMap(
         _ => BadRequest("invalid start date")
@@ -57,7 +60,7 @@ class LogvizRoutes(eventsource: EventSource, instancesource: InstanceSource) ext
       //we end up with same type on Either[IO[Response[IO]], IO[Response[IO]]
       //so we can then just merge to IO[Response[IO]]
       (start, end).mapN { (start, end) => 
-        val events = eventsource.getEvents(start, end)
+        val events = eventsource.getEvents(start, end, instance)
         val sse: EventStream[IO] = events.map(eventToServerSent)
         Ok(sse)
       }.merge
@@ -68,7 +71,7 @@ class LogvizRoutes(eventsource: EventSource, instancesource: InstanceSource) ext
       // hard coding times for now
       val end: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC)
       val start: LocalDateTime = end.minusHours(24)
-      val events = eventsource.getEvents(start, end)
+      val events = eventsource.getEvents(start, end, None)
       val sse: EventStream[IO] = events.map(eventToServerSent)
 
       Ok(sse)
@@ -96,5 +99,6 @@ class LogvizRoutes(eventsource: EventSource, instancesource: InstanceSource) ext
 
   object StartDateQueryParamMatcher extends ValidatingQueryParamDecoderMatcher[LocalDateTime]("startTime")
   object EndDateQueryParamMatcher extends ValidatingQueryParamDecoderMatcher[LocalDateTime]("endTime")
+  object InstanceQueryParamMatcher extends OptionalQueryParamDecoderMatcher[String]("instance")
   
 }

--- a/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
+++ b/modules/backend/src/main/scala/latis/logviz/LogvizRoutes.scala
@@ -39,11 +39,17 @@ class LogvizRoutes(eventsource: EventSource, instancesource: InstanceSource) ext
     case req @ GET -> Root / "events.json" =>
       StaticFile.fromResource("events.json", req.some).getOrElseF(NotFound())
 
+    case req @ GET -> Root / "events1.json" =>
+      StaticFile.fromResource("events1.json", req.some).getOrElseF(NotFound())
+
     case req @ GET -> Root / "styles.css" =>
       StaticFile.fromResource("styles.css", req.some).getOrElseF(NotFound())
 
     // event with query params
-    case req @ GET -> Root / "events" :? StartDateQueryParamMatcher(startTime) +& EndDateQueryParamMatcher(endTime) =>
+    case req @ GET -> Root / "events" :? 
+    StartDateQueryParamMatcher(startTime) +&
+    EndDateQueryParamMatcher(endTime) +&
+    InstanceQueryParamMatcher(instance) =>
 
       val start = startTime.toEither.leftMap(
         _ => BadRequest("invalid start date")
@@ -57,18 +63,17 @@ class LogvizRoutes(eventsource: EventSource, instancesource: InstanceSource) ext
       //we end up with same type on Either[IO[Response[IO]], IO[Response[IO]]
       //so we can then just merge to IO[Response[IO]]
       (start, end).mapN { (start, end) => 
-        val events = eventsource.getEvents(start, end)
+        val events = eventsource.getEvents(start, end, instance)
         val sse: EventStream[IO] = events.map(eventToServerSent)
         Ok(sse)
       }.merge
     
-    //TODO: unused as of right now
     //default (past 24 hours)
     case req @ GET -> Root / "events" =>
       // hard coding times for now
       val end: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC)
       val start: LocalDateTime = end.minusHours(24)
-      val events = eventsource.getEvents(start, end)
+      val events = eventsource.getEvents(start, end, None)
       val sse: EventStream[IO] = events.map(eventToServerSent)
 
       Ok(sse)
@@ -96,5 +101,6 @@ class LogvizRoutes(eventsource: EventSource, instancesource: InstanceSource) ext
 
   object StartDateQueryParamMatcher extends ValidatingQueryParamDecoderMatcher[LocalDateTime]("startTime")
   object EndDateQueryParamMatcher extends ValidatingQueryParamDecoderMatcher[LocalDateTime]("endTime")
+  object InstanceQueryParamMatcher extends OptionalQueryParamDecoderMatcher[String]("instance")
   
 }

--- a/modules/backend/src/main/scala/latis/logviz/SplunkEventSource.scala
+++ b/modules/backend/src/main/scala/latis/logviz/SplunkEventSource.scala
@@ -14,7 +14,7 @@ import latis.logviz.splunk.*
  * @param sclient the SplunkClient used to access splunk
  */
 class SplunkEventSource(sclient: SplunkClient, source: String, index: String) extends EventSource with InstanceSource {
-  override def getEvents(start: LocalDateTime, end: LocalDateTime): Stream[IO, Event] = {
+  override def getEvents(start: LocalDateTime, end: LocalDateTime, instance: Option[String]): Stream[IO, Event] = {
     sclient.query(start, end, source, index)
   }
 

--- a/modules/frontend/src/main/scala/latis/logviz/AutocompleteComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/AutocompleteComponent.scala
@@ -1,0 +1,104 @@
+package latis.logviz
+
+import cats.effect.IO
+import cats.effect.Resource
+import cats.syntax.all._
+import calico.html.io.{*, given}
+import fs2.dom.HtmlElement
+import fs2.dom.HtmlInputElement
+import fs2.concurrent.SignallingRef
+import fs2.concurrent.Signal
+
+/**
+ * Searchable dropdown component
+ * Currently used for instance selection
+ * Interacts with autocomplete store which holds states for things like dropdown and filter
+*/
+class AutocompleteComponent(instances: List[String]) {
+  def render: Resource[IO, HtmlElement[IO]] = 
+
+    for {
+      store        <- Resource.eval(AutocompleteStore())
+      autocomplete <- div(
+                        cls := "autocomplete",
+                        instanceInput(store),
+                        children <-- store.isOpen.map {
+                          case true =>
+                            List(ul(
+                              //TODO
+                              //think we can add a selected if it matches selected so then we can highlight or something in css
+                              cls := "instance-list",
+                              
+                              children <-- store.filteredInstances(instances).map { filteredList =>
+                                filteredList.map(i => 
+                                  li(
+                                    cls := "list-item",
+                                    onClick(store.select(i)),
+                                    i
+                                  ))
+                              }
+                            ))
+                          case false => Nil 
+                        }
+                      )
+
+    } yield(autocomplete)
+
+  /**
+   * Input for setting the filter
+   * Clicking will open a dropdown of instances that match filter
+  */
+  def instanceInput(store: AutocompleteStore): Resource[IO, HtmlInputElement[IO]] = 
+    input.withSelf { self => 
+      (
+        idAttr := "instance",
+        typ := "text",
+        placeholder := "Select Instance",
+        value <-- store.filter,
+
+        //not sure how to implement closing dropdown when clicking outside of the dropdown
+        onClick(store.openDropdown),
+        onInput(self.value.get.flatMap(store.setFilter(_)))
+        
+      )
+    }
+
+}
+
+/**
+ * Store for updating the state of certain things such as the filter, whether to show the dropdown list of instance, etc.
+ */
+class AutocompleteStore(autocompleteRef: SignallingRef[IO, Autocomplete]) {
+
+  def setFilter(f: String): IO[Unit] = autocompleteRef.update(_.copy(filter=f))
+
+  def openDropdown: IO[Unit] = autocompleteRef.update(_.copy(dropdown=true)) >> IO.println("Opening dropdown!")
+
+  //unused right now. I imagine that when we click outside of box, we would closedropdown, but not sure how that would be done
+  def closeDropdown: IO[Unit] = autocompleteRef.update(_.copy(dropdown=false))
+
+  //TODO: selecting multiple instances?
+  def select(instance: String): IO[Unit] = autocompleteRef.update(_.copy(filter=instance, dropdown=false, selected=instance))
+
+  //exposes signal for components to listen to on whether to create dropdown or not
+  def isOpen: Signal[IO, Boolean] = autocompleteRef.map(_.dropdown).changes
+
+  def filter: Signal[IO, String] = autocompleteRef.map(_.filter).changes
+
+  def filteredInstances(instances: List[String]): Signal[IO, List[String]] = 
+    autocompleteRef.map { autocomplete =>
+      val f = autocomplete.filter.toLowerCase()
+      instances.filter(i => i.toLowerCase.contains(f)) 
+    }.changes
+}
+
+
+object AutocompleteStore {
+  def apply(): IO[AutocompleteStore] =
+    SignallingRef[IO].of(Autocomplete("", false, "")).map(new AutocompleteStore(_))
+
+}
+case class Autocomplete(filter: String, dropdown: Boolean, selected: String)
+
+
+

--- a/modules/frontend/src/main/scala/latis/logviz/AutocompleteComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/AutocompleteComponent.scala
@@ -1,0 +1,110 @@
+package latis.logviz
+
+import cats.effect.IO
+import cats.effect.Resource
+import cats.syntax.all._
+import calico.html.io.{*, given}
+import fs2.dom.HtmlElement
+import fs2.dom.HtmlInputElement
+import fs2.concurrent.SignallingRef
+import fs2.concurrent.Signal
+
+/**
+ * Searchable dropdown component
+ * Currently used for instance selection
+ * Interacts with autocomplete store which holds states for things like dropdown and filter
+*/
+class AutocompleteComponent(instances: List[String], selectedInstance: SignallingRef[IO, String]) {
+  def render: Resource[IO, HtmlElement[IO]] = 
+
+    for {
+      store        <- Resource.eval(AutocompleteStore())
+      autocomplete <- div(
+                        cls := "autocomplete",
+                        div(
+                          cls:= "autocomplete-input-wrapper",
+                          instanceInput(store),
+                        ),
+                        children <-- store.isOpen.map {
+                          case true =>
+                            List(div( 
+                              cls:= "autocomplete-panel", 
+                              ul(
+                                //TODO
+                                //think we can add a selected if it matches selected so then we can highlight or something in css
+                                cls := "instance-list",
+                                
+                                children <-- store.filteredInstances(instances).map { filteredList =>
+                                  filteredList.map(i => 
+                                    li(
+                                      cls := "dropdown-item",
+                                      onClick(store.select(i) >> selectedInstance.set(i)),
+                                      i
+                                    ))
+                                }
+                              )
+                            ))
+                          case false => Nil 
+                        }
+                      )
+
+    } yield(autocomplete)
+
+  /**
+   * Input for setting the filter
+   * Clicking will open a dropdown of instances that match filter
+  */
+  def instanceInput(store: AutocompleteStore): Resource[IO, HtmlInputElement[IO]] = 
+    input.withSelf { self => 
+      (
+        idAttr := "instance",
+        typ := "text",
+        placeholder := "Select Instance",
+        value <-- store.filter,
+
+        //not sure how to implement closing dropdown when clicking outside of the dropdown
+        onClick(store.openDropdown),
+        onInput(self.value.get.flatMap(store.setFilter(_)))
+        
+      )
+    }
+
+}
+
+/**
+ * Store for updating the state of certain things such as the filter, whether to show the dropdown list of instance, etc.
+ */
+class AutocompleteStore(autocompleteRef: SignallingRef[IO, Autocomplete]) {
+
+  def setFilter(f: String): IO[Unit] = autocompleteRef.update(_.copy(filter=f))
+
+  def openDropdown: IO[Unit] = autocompleteRef.update(_.copy(dropdown=true))
+
+  //unused right now. I imagine that when we click outside of box, we would closedropdown, but not sure how that would be done
+  def closeDropdown: IO[Unit] = autocompleteRef.update(_.copy(dropdown=false))
+
+  //TODO: selecting multiple instances?
+  def select(instance: String): IO[Unit] = autocompleteRef.update(_.copy(filter=instance, dropdown=false, selected=instance))
+
+  //exposes signal for components to listen to on whether to create dropdown or not
+  def isOpen: Signal[IO, Boolean] = autocompleteRef.map(_.dropdown).changes
+
+  def filter: Signal[IO, String] = autocompleteRef.map(_.filter).changes
+
+  def filteredInstances(instances: List[String]): Signal[IO, List[String]] = 
+    autocompleteRef.map { autocomplete =>
+      val f = autocomplete.filter.toLowerCase()
+      instances.filter(i => i.toLowerCase.contains(f)) 
+    }.changes
+}
+
+
+object AutocompleteStore {
+  def apply(): IO[AutocompleteStore] =
+    SignallingRef[IO].of(Autocomplete("", false, "")).map(new AutocompleteStore(_))
+
+}
+case class Autocomplete(filter: String, dropdown: Boolean, selected: String)
+
+
+

--- a/modules/frontend/src/main/scala/latis/logviz/EventClient.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventClient.scala
@@ -16,20 +16,22 @@ import java.time.LocalDateTime
 
 /** EventClient used to return stream of events */
 trait EventClient {
-  def getEvents(startTime: String, endTime: Option[String]): Stream[IO, Event]
+  def getEvents(startTime: String, endTime: Option[String], instance: Option[String]): Stream[IO, Event]
 
   //no given start and end time: past 24 hours + live
   def getEvents: Stream[IO, Event] =
     val curr = LocalDateTime.now(java.time.ZoneId.of("UTC"))
     val start = curr.toLocalDate().atStartOfDay().toString()
-    getEvents(start, None)
+    getEvents(start, None, None)
 
   //no end time (live)
   def getEvents(start: String): Stream[IO, Event] = 
-    getEvents(start, None)
+    getEvents(start, None, None)
 
   def getEvents(start: String, end: String): Stream[IO, Event] = 
-    getEvents(start, Some(end))
+    getEvents(start, Some(end), None)
+
+  // def getInstances: IO[List[String]]
 }
 
 object EventClient {
@@ -53,7 +55,9 @@ object EventClient {
       val baseUri = Uri.unsafeFromString(s"$protocol//$host")
 
       new EventClient {
-        override def getEvents(startTime: String, endTime: Option[String]): Stream[IO, Event] =         
+        //TODO:
+        //should there be a default instance?
+        override def getEvents(startTime: String, endTime: Option[String], instance: Option[String]): Stream[IO, Event] =         
           
           val uri = endTime match {
             case None => 
@@ -87,6 +91,14 @@ object EventClient {
               }
               .unNone
           }
+
+        //TODO:
+        //since /instances is giving us a json back, do we need circe?
+        // override def getInstances: IO[List[String]] = 
+        //   val uri = Uri.unsafeFromString(s"$baseUri/instances")
+        //   val request = Request[IO](method = Method.GET, uri = uri)
+
+        //   http.expect[List[String]](request)
       }
     }
 }

--- a/modules/frontend/src/main/scala/latis/logviz/EventClient.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventClient.scala
@@ -1,10 +1,13 @@
 package latis.logviz
 
+import java.time.LocalDateTime
+
 import cats.effect.IO
 import cats.syntax.all.*
 import fs2.Stream
 import fs2.dom.Window
 import io.circe.parser.*
+import org.http4s.circe.*
 import org.http4s.Method
 import org.http4s.Request
 import org.http4s.ServerSentEvent
@@ -12,24 +15,30 @@ import org.http4s.Uri
 import org.http4s.client.Client
 
 import latis.logviz.model.Event
-import java.time.LocalDateTime
 
 /** EventClient used to return stream of events */
 trait EventClient {
-  def getEvents(startTime: String, endTime: Option[String]): Stream[IO, Event]
+  def getEvents(startTime: String, endTime: Option[String], instance: Option[String]): Stream[IO, Event]
 
   //no given start and end time: past 24 hours + live
   def getEvents: Stream[IO, Event] =
     val curr = LocalDateTime.now(java.time.ZoneId.of("UTC"))
     val start = curr.toLocalDate().atStartOfDay().toString()
-    getEvents(start, None)
+    getEvents(start, None, None)
 
   //no end time (live)
-  def getEvents(start: String): Stream[IO, Event] = 
-    getEvents(start, None)
+  // def getEvents(start: String): Stream[IO, Event] = 
+  //   getEvents(start, None, Some("json1"))
 
-  def getEvents(start: String, end: String): Stream[IO, Event] = 
-    getEvents(start, Some(end))
+  // def getEvents(start: String, end: String): Stream[IO, Event] = 
+  //   getEvents(start, Some(end), Some("json1"))
+
+  def getEvents(start: String, end: String, instance: String): Stream[IO, Event] = 
+    getEvents(start, Some(end), Some(instance))
+
+
+
+  def getInstances: IO[List[String]]
 }
 
 object EventClient {
@@ -53,20 +62,17 @@ object EventClient {
       val baseUri = Uri.unsafeFromString(s"$protocol//$host")
 
       new EventClient {
-        override def getEvents(startTime: String, endTime: Option[String]): Stream[IO, Event] =         
-          
-          val uri = endTime match {
-            case None => 
-              //TODO:
-              //using current time as the endtime if none is given
-              //should a live query parameter be added?
-              //how would real sources like splunk know to give realtime data?
-              val endTime = LocalDateTime.now(java.time.ZoneId.of("UTC"))
-              val end = endTime.toString()
-              Uri.unsafeFromString(s"$baseUri/events?startTime=$startTime&endTime=$end")
-            
+        override def getEvents(startTime: String, endTime: Option[String], instance: Option[String]): Stream[IO, Event] =         
+          val end = endTime match {
+            case Some(value) => value
+            case None => LocalDateTime.now(java.time.ZoneId.of("UTC")).toString()
+          }
+
+          val uri = instance match {
             case Some(value) => 
-              Uri.unsafeFromString(s"$baseUri/events?startTime=$startTime&endTime=$value")
+              Uri.unsafeFromString(s"$baseUri/events?startTime=$startTime&endTime=$end&instance=$value")
+            case None =>
+              Uri.unsafeFromString(s"$baseUri/events?startTime=$startTime&endTime=$end")
           }
 
           val request = Request[IO](method = Method.GET, uri = uri)
@@ -87,6 +93,13 @@ object EventClient {
               }
               .unNone
           }
+
+        override def getInstances: IO[List[String]] = {
+          val uri = Uri.unsafeFromString(s"$baseUri/instances")
+          val request = Request[IO](method = Method.GET, uri = uri)
+
+          http.expect(request)(jsonOf[IO, List[String]])
+        }
       }
     }
 }

--- a/modules/frontend/src/main/scala/latis/logviz/Main.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/Main.scala
@@ -118,8 +118,10 @@ object Main extends IOWebApp {
       component   =  new EventComponent(events, eventRef, startRef, endRef, liveRef, zoomRef)
       timeline    <- component.render
 
+      autocomplete <- new AutocompleteComponent(List("latis3-swp", "webtcad", "latis-swp", "lisird", "test")).render
+
       requestInfo <- div(idAttr:= "request-detail", info)
-      box         <- div(idAttr:= "box", timeline, zoom, requestInfo, timeSelect)
+      box         <- div(idAttr:= "box", timeline, zoom, requestInfo, timeSelect, autocomplete)
       html        <- div(idAttr:= "container", box)
       
   } yield html

--- a/modules/frontend/src/main/scala/latis/logviz/Main.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/Main.scala
@@ -7,9 +7,11 @@ import calico.IOWebApp
 import calico.html.io.{*, given}
 import cats.effect.IO
 import cats.effect.Resource
+import cats.syntax.all.*
 import fs2.Stream
 import cats.effect.kernel.Ref
 import fs2.concurrent.SignallingRef
+import fs2.concurrent.Signal
 import fs2.dom.HtmlElement
 import org.http4s.dom.FetchClientBuilder
 import org.http4s.client.Client
@@ -39,6 +41,7 @@ object Main extends IOWebApp {
       endRef      <- Resource.eval(SignallingRef[IO].of(now))
       liveRef     <- Resource.eval(SignallingRef[IO].of(false))
       events      <- Resource.eval(SignallingRef[IO].of[Stream[IO, Event]](ec.getEvents))
+      instanceRef <- Resource.eval(SignallingRef[IO].of[String](""))
 
       liveButton  <- button( 
                       `type` := "button",
@@ -49,27 +52,29 @@ object Main extends IOWebApp {
                       },
                       onClick(_ => {
                         for {
-                          //TODO "disabling" endtime when live so visually looks like its not being used?
+                          //TODO "disabling/greying out" endtime button when live so visually looks like its not being used?
                           live  <- liveRef.updateAndGet(bool => !bool)
 
-                          end     <- if (!live) {
+                          _     <- if (!live) {
                                       //going from live to not live: visually it'll look like the canvas stopped moving
                                       //so endtime should just be where we left off
-                                      endRef.updateAndGet(t => LocalDateTime.now(ZoneOffset.UTC))
+                                      endRef.update(t => LocalDateTime.now(ZoneOffset.UTC))
                                       
                                     } else {
                                       IO.unit
                                     }
 
-                          start <- startRef.get
+                          // start <- startRef.get
 
-                          _     <- if (live) {
-                                      events.set(ec.getEvents(start.toString()))
-                                    } else {
-                                      //updating endRef already calls getevents correctly, so I dont think I need it again
-                                      //events.set(ec.getEvents(start.toString(), end.toString()))
-                                      IO.unit
-                                    }
+                          //if I just have params take liveref, then changes to liveref should trigger a change right?
+                          // _     <- if (live) {
+                          //             startRef.set(start)
+                          //             // events.set(ec.getEvents(start.toString()))
+                          //           } else {
+                          //             //updating endRef already calls getevents correctly, so I dont think I need it again
+                          //             //events.set(ec.getEvents(start.toString(), end.toString()))
+                          //             IO.unit
+                          //           }
                           
                         } yield ()
                       })
@@ -84,28 +89,29 @@ object Main extends IOWebApp {
                         )
                       )
       
-      //changes made to the start and end times should trigger new stream of events
       sup         <- Supervisor[IO](await=true)
-      _           <- Resource.eval(sup.supervise(endRef.discrete.evalMap{end => 
-                      //if an end time if given, then no longer expecting live stream of events
-                      liveRef.set(false) >> startRef.get.flatMap { start =>
-                        events.set(ec.getEvents(start.toString(), end.toString()))
-                      }
-                    }.compile.drain).void)
 
-      _           <- Resource.eval(sup.supervise(startRef.discrete.evalMap{t => 
-                        for {
-                          live  <- liveRef.get
-                          start = t.toString
+      //probably don't need this anymore since we're combining signal in params
+      // _           <- Resource.eval(sup.supervise(endRef.discrete.evalMap{end => 
+      //                 //if an end time if given, then no longer expecting live stream of events
+      //                 liveRef.set(false) >> startRef.get.flatMap { start =>
+      //                   events.set(ec.getEvents(start.toString(), end.toString()))
+      //                 }
+      //               }.compile.drain).void)
 
-                          _     <- if (live) {
-                                    events.set(ec.getEvents(start))
-                                  } else {
-                                    endRef.get.flatMap(end => events.set(ec.getEvents(start, end.toString())))
-                                  }
+      // _           <- Resource.eval(sup.supervise(startRef.discrete.evalMap{t => 
+      //                   for {
+      //                     live  <- liveRef.get
+      //                     start = t.toString
 
-                        } yield()
-                      }.compile.drain).void)
+      //                     _     <- if (live) {
+      //                               events.set(ec.getEvents(start))
+      //                             } else {
+      //                               endRef.get.flatMap(end => events.set(ec.getEvents(start, end.toString())))
+      //                             }
+
+      //                   } yield()
+      //                 }.compile.drain).void)
 
       timeRange   <- new TimeRangeComponent(startRef, endRef, liveRef).render
       timeSelect  <- div(idAttr:= "time-selection", liveButton, timeRange)  
@@ -117,9 +123,24 @@ object Main extends IOWebApp {
       info        <- evComponent.render
       component   =  new EventComponent(events, eventRef, startRef, endRef, liveRef, zoomRef)
       timeline    <- component.render
+      
+      instances   <- Resource.eval(ec.getInstances)
+      autocomplete<- new AutocompleteComponent(instances, instanceRef).render
+
+      //any changes to any of these signallingrefs should trigger a getevents call
+      params      = (startRef.asInstanceOf[Signal[IO, LocalDateTime]], 
+                     endRef.asInstanceOf[Signal[IO, LocalDateTime]], 
+                     instanceRef.asInstanceOf[Signal[IO, String]],
+                     liveRef.asInstanceOf[Signal[IO, Boolean]]).mapN{
+                      (start, end, instance, live) => (start, end, instance)
+                    }
+
+      _           <- Resource.eval(sup.supervise(params.discrete.switchMap { (s, e, i) => 
+                        Stream.exec(events.set(ec.getEvents(s.toString(), e.toString(), i)))
+                  }.compile.drain).void)
 
       requestInfo <- div(idAttr:= "request-detail", info)
-      box         <- div(idAttr:= "box", timeline, zoom, requestInfo, timeSelect)
+      box         <- div(idAttr:= "box", timeline, zoom, requestInfo, timeSelect, autocomplete)
       html        <- div(idAttr:= "container", box)
       
   } yield html


### PR DESCRIPTION
This ticket adds the ability to select a specific LaTiS instance. 

Autocomplete component takes a list of instances from /instances and displays them in a dropdown and filters on search
- A lot of the implementation was inspired by [Calico TodoMVC](https://www.armanbilge.com/calico/demos/todomvc.html) with using a store for the state and exposing signals for the html attributes

Events endpoint now takes instance as a query parameter

Created an additional events.json to test instance selection

Combined start, end, instance, and live signallingrefs so that any changes to those refs will trigger a call to getevents

A couple of other tasks for the future:
- highlighting the selected instance in the dropdown
- having this instance selection work for splunk (I think we replace source?)
- closing dropdown when clicking outside of it
- allowing multiple instances
- BUG: ran into a chunked encoding error when an events json doesn't contain any future events. (Not necessarily a blocking issue since this is only an issue with the json event source)
