### PR TITLE
Instance selection queries Splunk with new instance

### DIFF
--- a/modules/backend/src/main/scala/latis/logviz/SplunkEventSource.scala
+++ b/modules/backend/src/main/scala/latis/logviz/SplunkEventSource.scala
@@ -15,7 +15,10 @@ import latis.logviz.splunk.*
  */
 class SplunkEventSource(sclient: SplunkClient, source: String, index: String) extends EventSource with InstanceSource {
   override def getEvents(start: LocalDateTime, end: LocalDateTime, instance: Option[String]): Stream[IO, Event] = {
-    sclient.query(start, end, source, index)
+    instance match {
+      case Some("") | None => sclient.query(start, end, source, index)
+      case Some(inst)      => sclient.query(start, end, inst, index)
+    }
   }
 
   override def instances: IO[List[String]] = {

--- a/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkClient.scala
+++ b/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkClient.scala
@@ -243,7 +243,7 @@ object SplunkClient {
             */
           def enumerateSources: IO[List[(String, Long)]] = {
             // filtering based on latest time but we could also filter based on the total amount of events?
-            val query = s"| tstats max(_time) AS latest WHERE source=latis* AND (index=latis OR index=dev) by source | sort -latest"
+            val query = s"| tstats max(_time) AS latest WHERE source=latis* AND index=latis by source | sort -latest"
 
             (for {
               authHeader <- makeAuthHeader


### PR DESCRIPTION
Selecting an instance now queries Splunk with the new instance and returns the new stream of events. Instances can be selected from both JSON and Splunk sources, but the drawing of events for both don't seem to work.