### PR TITLE
Parsing Errors

### DIFF
--- a/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
@@ -402,7 +402,7 @@ class EventComponent(
                                 val shortUrl = url.split("\\?")(0)
                                 EventDetails("Success", start, end, s"$duration ms", s"$shortUrl")
                               case RequestEvent.Failure(start, url, end, msg) => 
-                                val duration = Duration.between(LocalDateTime.parse(start), LocalDateTime.parse(end))
+                                val duration = Duration.between(LocalDateTime.parse(start), LocalDateTime.parse(end)).toMillis()
                                 EventDetails(s"Failure: $msg", start, end, s"$duration ms", url)
                               case RequestEvent.Partial(end, msg) =>
                                 if (msg.contains("msg: ")) {

--- a/modules/frontend/src/main/scala/latis/logviz/EventParser.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventParser.scala
@@ -197,7 +197,7 @@ object EventParser {
                             >> IO(currDepth)
                           case Some((RequestEvent.Partial(start, status), currDepth)) =>
                             compEventsRef.update(lst =>
-                              (RequestEvent.Partial(time, s"successful event with response status of: $status, error msg: $msg"), 
+                              (RequestEvent.Partial(time, s"failed event with response status of: $status, error msg: $msg"), 
                               currDepth) +: lst)
                             >> IO(currDepth)
                           case Some((_, currDepth)) => 

--- a/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkClient.scala
+++ b/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkClient.scala
@@ -207,6 +207,12 @@ object SplunkClient {
               else if line.contains("Ember-Server service bound to address:") then
                 val time = line.split(" INFO")(0).drop(1)
                 Some(Event.Start(time))
+              else if line.contains("Exception thrown during response") then
+                val spl = line.split("Exception")
+                val id = spl(0).split("request-id=")(1).dropRight(3)
+                val time = spl(0).split(" ERROR")(0).drop(1)
+                val msg = line.split(id)(1).drop(3)
+                Some(Event.Failure(id, time, msg))
               else
                 None
             }


### PR DESCRIPTION
To parse events that resulted in a failure, logic was added to parse events that included "Exception thrown during response", which acts the same way as a success does. The other error string that we can expect ("Request failed") is a fourth event (as opposed to the typical request-response-success) that occurs after a request and before a response. These, afaik, return a status >400, and so Jerry's logic for a response with a status >=400 parses these events already. I kept the hover details the same, which includes the status in the event type at the top of the event details.