### PR TITLE
Partial events drawn off of canvas

### DIFF
--- a/modules/frontend/src/main/scala/latis/logviz/EventParser.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventParser.scala
@@ -174,7 +174,7 @@ object EventParser {
                                               "No unused column available. Increase number of columns!!!"))
                                           }
                               c         <- colCounter.updateAndGet(c => c + 1)
-                              _         <- maxCounter.update(prev => math.max(prev, c))
+                              _         <- maxCounter.update(prev => math.max(prev, currDepth.number + 1)) // maxCounter is 1-indexed
                               _         <- compEventsRef.update(lst => 
                                             (RequestEvent.Partial(time, s"partial success event- start time unknown. duration: $duration"), 
                                             currDepth) +: lst)


### PR DESCRIPTION
Some partial events are being drawn too far to the right on the canvas, i.e. the canvas isn't being drawn with the correct amount of columns for partial events to be seen. The blue from the partial event can be seen just barely on the right but the column it is drawn in doesn't seem to be given to the canvas so that all columns and events are visible. In `eventParser`, `colCounter` is used to keep track of the current number of concurrent events at a given time. As the parser goes through and keeps track of events that have requests but no successes yet, this number increments. As successes are found, this number decrements. Since partial events (in this case) have an end time but no start time, we are relying on the number of concurrent events at the time the event ends, which tends to be a smaller number. Since we were originally comparing this number to `maxCounter`, which measures the maximum number of concurrent events, this value didn't get updated and partial events were being drawn "outside" of the canvas. Instead, the depth of the column is used, as this accounts for the column that the partial event is drawn in.