### PR TITLE
Alert user when no events returned

### DIFF
--- a/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
@@ -19,7 +19,7 @@ import cats.effect.kernel.Ref
 import fs2.concurrent.Signal
 import fs2.concurrent.SignallingRef
 import fs2.dom.HtmlElement
-import fs2.Pull
+// import fs2.Pull
 import fs2.Stream
 
 import latis.logviz.model.Event
@@ -64,28 +64,30 @@ class EventComponent(
       eParser       <- Resource.eval(EventParser())
       parserRef     <- Resource.eval(Ref[IO].of(eParser))
       parserUpdated <- Resource.eval(Ref[IO].of(false))
-        _           <- Resource.eval(sup.supervise(signal.discrete.drop(1).switchMap { eventStream => 
+      alertRef      <- Resource.eval(Ref[IO].of(true))
+      _             <- Resource.eval(sup.supervise(signal.discrete.drop(1).switchMap { eventStream => 
                         // making a new parser
                         val newParser = for {
                           parser <- EventParser()
                           _      <- parserRef.set(parser)
+                          _      <- alertRef.set(true)
                         } yield parser
 
-                        val alert: Stream[IO, Event] = eventStream.pull.uncons1.flatMap {
-                          case Some((el, strm)) =>
-                            Pull.output1(el)
-                          case None => 
+                        val parseEvents = Stream.eval(newParser).flatMap { parser =>
+                          eventStream.evalTap { event =>
+                            alertRef.set(false) >>
+                            parser.parse(event).handleErrorWith(IO.println) >> parserUpdated.set(true)
+                          }
+                        } 
+
+                        val alert = alertRef.get.flatMap { empty =>
+                          if (empty) {
                             dom.window.alert("No events returned from query.")
-                            Pull.done
-                        }.stream
-                        
-                        alert.flatMap { _ =>
-                          Stream.eval(newParser).flatMap { parser =>
-                            eventStream.evalTap(
-                              parser.parse(_).handleErrorWith(IO.println) >> parserUpdated.set(true)
-                            )
-                          } 
+                          }
+                          IO.unit
                         }
+
+                        parseEvents ++ Stream.eval(alert)
                       }.compile.drain).void)
       scrollRef     <- Resource.eval(Ref[IO].of(0.0))
       isTop         <- Resource.eval(Ref[IO].of(true))

--- a/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
@@ -80,10 +80,9 @@ class EventComponent(
                         } 
 
                         val alert = alertRef.get.flatMap { empty =>
-                          if (empty) {
+                          IO {
                             dom.window.alert("No events returned from query.")
-                          }
-                          IO.unit
+                          }.whenA(empty)
                         }
 
                         parseEvents ++ Stream.eval(alert)

--- a/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
@@ -19,6 +19,7 @@ import cats.effect.kernel.Ref
 import fs2.concurrent.Signal
 import fs2.concurrent.SignallingRef
 import fs2.dom.HtmlElement
+import fs2.Pull
 import fs2.Stream
 
 import latis.logviz.model.Event
@@ -63,18 +64,28 @@ class EventComponent(
       eParser       <- Resource.eval(EventParser())
       parserRef     <- Resource.eval(Ref[IO].of(eParser))
       parserUpdated <- Resource.eval(Ref[IO].of(false))
-        _           <- Resource.eval(sup.supervise(signal.discrete.switchMap { stream => 
+        _           <- Resource.eval(sup.supervise(signal.discrete.drop(1).switchMap { eventStream => 
                         // making a new parser
                         val newParser = for {
                           parser <- EventParser()
                           _      <- parserRef.set(parser)
                         } yield parser
+
+                        val alert: Stream[IO, Event] = eventStream.pull.uncons1.flatMap {
+                          case Some((el, strm)) =>
+                            Pull.output1(el)
+                          case None => 
+                            dom.window.alert("No events returned from query.")
+                            Pull.done
+                        }.stream
                         
-                        Stream.eval(newParser).flatMap { parser =>
-                          stream.evalTap(
-                            parser.parse(_).handleErrorWith(IO.println) >> parserUpdated.set(true)
-                          )
-                        } 
+                        alert.flatMap { _ =>
+                          Stream.eval(newParser).flatMap { parser =>
+                            eventStream.evalTap(
+                              parser.parse(_).handleErrorWith(IO.println) >> parserUpdated.set(true)
+                            )
+                          } 
+                        }
                       }.compile.drain).void)
       scrollRef     <- Resource.eval(Ref[IO].of(0.0))
       isTop         <- Resource.eval(Ref[IO].of(true))

--- a/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
@@ -19,7 +19,6 @@ import cats.effect.kernel.Ref
 import fs2.concurrent.Signal
 import fs2.concurrent.SignallingRef
 import fs2.dom.HtmlElement
-// import fs2.Pull
 import fs2.Stream
 
 import latis.logviz.model.Event


### PR DESCRIPTION
Sets up a Ref to track whether any events from the stream have been parsed. If no events are parsed, the stream is empty, and no events were returned from Splunk, and an alert tells the user that no events were found. 