### PR TITLE
Drawing line at last event parsed when Splunk limit is reached

### DIFF
--- a/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
@@ -6,6 +6,8 @@ import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.time.format.DateTimeFormatter
 
+import scala.scalajs.js
+
 import org.scalajs.dom
 import org.scalajs.dom.HTMLElement
 import org.scalajs.dom.HTMLCanvasElement
@@ -63,6 +65,7 @@ class EventComponent(
       eParser       <- Resource.eval(EventParser())
       parserRef     <- Resource.eval(Ref[IO].of(eParser))
       parserUpdated <- Resource.eval(Ref[IO].of(false))
+      lineRef       <- Resource.eval(Ref[IO].of(false))
       alertRef      <- Resource.eval(Ref[IO].of(true))
       _             <- Resource.eval(sup.supervise(signal.discrete.drop(1).switchMap { eventStream => 
                         // making a new parser
@@ -72,12 +75,25 @@ class EventComponent(
                           _      <- alertRef.set(true)
                         } yield parser
 
-                        val parseEvents = Stream.eval(newParser).flatMap { parser =>
+                        val parseEvents = Stream.eval(newParser).flatMap { parser =>                          
                           eventStream.evalTap { event =>
+                            event match {
+                              case Event.Start("splunk max reached") =>
+                                val msg = "50,000 event limit from Splunk was reached, indicating a " +
+                                  "large time range or noise in logs. A dashed line was drawn where the " +
+                                  "last event was parsed."
+                                IO(dom.window.alert(msg)) >> lineRef.set(true)
+                              case _ =>
+                                IO.unit
+                            }
+                          }.dropLastIf {
+                            case Event.Start("splunk max reached") => true
+                            case _ => false
+                          }.evalTap { event =>
                             alertRef.set(false) >>
                             parser.parse(event).handleErrorWith(IO.println) >> parserUpdated.set(true)
                           }
-                        } 
+                        }
 
                         val alert = alertRef.get.flatMap { empty =>
                           IO {
@@ -101,7 +117,8 @@ class EventComponent(
                         isTop, 
                         rectRef,
                         prevZoomRef,
-                        parserUpdated)
+                        parserUpdated,
+                        lineRef)
       _             <- hover(canvas, eventRef, rectRef)
     } yield(timeline)
   
@@ -134,6 +151,8 @@ class EventComponent(
    * @param cols number of columns to draw
    * @param top   current scroll position from the top
    * @param width total available space for columns to be drawn
+   * @param line flag to draw a line at last event parsed
+   * @param lastEv the last event from the stream
   */
   private def drawCanvas(
     end: LocalDateTime,
@@ -143,7 +162,9 @@ class EventComponent(
     cols: Int,
     top: Double,
     width: Int,
-    pixelsPerSec: Double
+    pixelsPerSec: Double,
+    line: Boolean,
+    lastEv: List[Rectangle]
   ): IO[Unit] =
 
     //computes what the top of the canvas(viewport) is
@@ -186,6 +207,7 @@ class EventComponent(
             case Rectangle(event, x, y, width, height, color) => 
               drawRect(context, x, y, width, height, color)
             }
+      _ <- drawLine(context, width, lastEv).whenA(line)
     } yield()
 
 
@@ -205,6 +227,39 @@ class EventComponent(
       context.lineWidth = 0.3
       context.strokeStyle = "black"
       context.strokeRect(x, y, width, duration)
+  }
+
+  /**
+   * Draw a line denoting the last event drawn by Logviz
+   * 
+   * @param context
+   * @param width total available space for columns to be drawn
+   * @param lastRect the last event that will be drawn
+  */
+  private def drawLine(
+    context: dom.CanvasRenderingContext2D,
+    width: Int,
+    lastRect: List[Rectangle]
+  ): IO[Unit] = IO {
+    if (!lastRect.isEmpty) {
+      context.setLineDash(js.Array(10, 10))
+      context.beginPath()
+
+      val rect = lastRect(0)
+
+      rect.event._1 match {
+        case RequestEvent.Server(_) | RequestEvent.Request(_, _) =>
+          context.moveTo(150, rect.y)
+          context.lineTo(150 + width, rect.y)
+        case _ =>
+          context.moveTo(150, rect.y + rect.height)
+          context.lineTo(150 + width, rect.y + rect.height)
+      }
+
+      context.closePath()
+      context.stroke()
+      context.setLineDash(js.Array())
+    }
   }
   
   private def drawTS(
@@ -243,7 +298,8 @@ class EventComponent(
     isTop: Ref[IO, Boolean],
     rectRef: Ref[IO, List[Rectangle]],
     prevZoomRef: Ref[IO, Double],
-    parserUpdated: Ref[IO, Boolean]
+    parserUpdated: Ref[IO, Boolean],
+    lineRef: Ref[IO, Boolean]
   ): Resource[IO, Dispatcher[IO]] =
     Dispatcher.sequential[IO] evalTap{ dispatcher => 
 
@@ -260,6 +316,7 @@ class EventComponent(
           zoomLev     <- zoomRef.get
           parser      <- parserRef.get
           newParser   <- parserUpdated.get
+          drawLine    <- lineRef.get
 
           //if live, then possible scenarios: 
           //  - at top of canvas so continuously redrawing each animation frame
@@ -292,6 +349,14 @@ class EventComponent(
                                   }
                         maxCol  <- parser.getMaxConcurrent()
                         events  <- parser.getEvents()
+                        lastEv  <- parser.getLastEvent(events)
+                        lastRect = Rectangles.makeRectangles(end,
+                                    height,
+                                    newTop,
+                                    width/maxCol,
+                                    lastEv,
+                                    start,
+                                    zoomLev)
                         rects   = Rectangles.makeRectangles(endTime,
                                    height,
                                    newTop,
@@ -307,7 +372,9 @@ class EventComponent(
                                     maxCol,
                                     newTop,
                                     width,
-                                    zoomLev)
+                                    zoomLev,
+                                    drawLine,
+                                    lastRect)
                         _       <- prevScrollPos.update(_ => newTop)
                         _       <- if (newTop == 0.0) {
                                     isTop.update(_ => true)
@@ -336,6 +403,14 @@ class EventComponent(
                                   }
                           maxCol  <- parser.getMaxConcurrent()
                           events  <- parser.getEvents()
+                          lastEv  <- parser.getLastEvent(events)
+                          lastRect = Rectangles.makeRectangles(end,
+                                      height,
+                                      newTop,
+                                      width/maxCol,
+                                      lastEv,
+                                      start,
+                                      zoomLev)
                           rects   = Rectangles.makeRectangles(end,
                                     height,
                                     newTop,
@@ -351,7 +426,9 @@ class EventComponent(
                                       maxCol,
                                       newTop,
                                       width,
-                                      zoomLev)
+                                      zoomLev,
+                                      drawLine,
+                                      lastRect)
                           _       <- prevScrollPos.update(_ => newTop)
                           //_       <- prevEndRef.set(end)
                           _       <- prevZoomRef.set(zoomLev)

--- a/modules/frontend/src/main/scala/latis/logviz/EventParser.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventParser.scala
@@ -1,5 +1,8 @@
 package latis.logviz
 
+import java.time.format.DateTimeFormatter
+import java.time.LocalDateTime
+
 import cats.effect.IO
 import cats.effect.kernel.Ref
 import cats.effect.std.PQueue
@@ -13,6 +16,7 @@ trait EventParser {
   def getEvents(): IO[List[(RequestEvent, Int)]]
   def getMaxConcurrent(): IO[Int]
   def getUnusedColumn(pq: PQueue[IO, Column], acc: List[Column] = Nil): IO[Option[Column]]
+  def getLastEvent(lst: List[(RequestEvent, Int)]): IO[List[(RequestEvent, Int)]]
 }
 
 /**
@@ -271,6 +275,33 @@ object EventParser {
             //pq is empty: meaning no columns that are unused -> need to increase max number of columns
             acc.traverse(pq.offer(_))
             >> IO(None)
+        }
+
+      override def getLastEvent(reqEvents: List[(RequestEvent, Int)]): IO[List[(RequestEvent, Int)]] = 
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")
+
+        def getTime(ev: RequestEvent): LocalDateTime =
+          ev match {
+            case RequestEvent.Server(time) => LocalDateTime.parse(time, formatter)
+            case RequestEvent.Request(start, _) => LocalDateTime.parse(start, formatter)
+            case RequestEvent.Success(_, _, end, _) => LocalDateTime.parse(end, formatter)
+            case RequestEvent.Failure(_, _, end, _) => LocalDateTime.parse(end, formatter)
+            case RequestEvent.Partial(end, _) => LocalDateTime.parse(end, formatter)
+          }
+        
+        def latestTime(lst: List[(RequestEvent, Int)], curr: (RequestEvent, Int)): (RequestEvent, Int) = lst match {
+          case Nil => curr
+          case head :: tail => 
+            val time1 = getTime(curr._1)
+            val time2 = getTime(head._1)
+            latestTime(tail, if (time1.isAfter(time2)) curr else head)
+        }
+
+        reqEvents match {
+          case Nil => IO(List())
+          case head :: tail => IO {
+            List(latestTime(tail, head))
+          }
         }
     }
   }

--- a/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkClient.scala
+++ b/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkClient.scala
@@ -172,7 +172,7 @@ object SplunkClient {
             * @param response the JSON results from the Splunk search
             * @return a stream of Event objects
             */
-          private def makeStream(response: Json): Stream[IO, Event] = { 
+          private def makeStream(response: Json, total: Int): Stream[IO, Event] = { 
             // making a stream of messages
             val decodedResult = response.hcursor.downField("results").as[List[SplunkMessage]]
             val mStrm: Stream[IO, SplunkMessage] = decodedResult match {
@@ -219,7 +219,13 @@ object SplunkClient {
 
             // stream of messages -> stream of events
             val eStrm: Stream[IO, Event] = mStrm.map(getEvent).unNone
-            eStrm
+
+            if (total >= 50000) {
+              val alertEvent = Event.Start("splunk max reached")
+              eStrm ++ Stream.emit(alertEvent)
+            } else {
+              eStrm
+            }
           }
 
           /** Queries Splunk with a given search and returns the events as a stream of Event objects
@@ -240,7 +246,7 @@ object SplunkClient {
                 _          <- waitLoop(authHeader, sid) // Step 3: Check the status of a query
                 total      <- getTotalResults(authHeader, sid)
                 res        <- getResults(authHeader, sid, total) // Step 4: Get the results from the query
-              } yield res
+              } yield (res, total)
             }.flatMap(makeStream) // Step 5: Make a stream of logs and get a stream of events
           }
 


### PR DESCRIPTION
The Splunk REST API will return a maximum of 50,000 events at a time, where paging can then be used to get following events for a query. Of these, only a small portion are parseable by Logviz, so we stop drawing events at some point in time because we reached the limit in the query. 

If we hit this limit, an extra event is added to the end of the stream. If this event is found in the stream, a `Ref` is set to true and passed to `drawCanvas` so the drawing of the line acts like the drawing of everything else on the canvas. A new method was added to `EventParser` to determine the last event that will be drawn, since `parser.getEvents()` does not order events chronologically. To determine the coordinates of the event, it is passed through `Rectangles.makeRectangles()`, which returns a list. Since the last event should always be a list of a single item (based on the recursive logic for finding the latest time), the last rectangle should also either always be a list of a single item or an empty list. (An empty list signifies that the thing to be drawn is not currently on a user's viewport). A new method `drawLine()` was added to draw the dashed line. An alert was also added to notify users when this occurred and to look for a dashed line.