### PR TITLE
Usage of "Reload Source" button

### DIFF
--- a/modules/backend/src/main/resources/styles.css
+++ b/modules/backend/src/main/resources/styles.css
@@ -52,11 +52,23 @@ input:valid+span::after {
 #start-time {
   display: flex;
   align-items: center;
+  height: auto;
+}
+
+#start-time p {
+  margin-top: 8px;
+  margin-bottom: 8px;
 }
 
 #end-time {
   display: flex;
   align-items: center;
+}
+
+#end-time p {
+  margin-top: 8px;
+  margin-bottom: 0
+  8px;
 }
 
 #time-range {

--- a/modules/backend/src/main/resources/styles.css
+++ b/modules/backend/src/main/resources/styles.css
@@ -53,22 +53,14 @@ input:valid+span::after {
   display: flex;
   align-items: center;
   height: auto;
-}
-
-#start-time p {
-  margin-top: 8px;
   margin-bottom: 8px;
 }
 
 #end-time {
   display: flex;
   align-items: center;
-}
-
-#end-time p {
   margin-top: 8px;
-  margin-bottom: 0
-  8px;
+  margin-bottom: 8px;
 }
 
 #time-range {
@@ -116,6 +108,8 @@ input:valid+span::after {
 
 #instance {
   width: 100%;
+  box-sizing: border-box;
+  margin-top: 6px;
 }
 
 .autocomplete-panel {

--- a/modules/frontend/src/main/scala/latis/logviz/Main.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/Main.scala
@@ -79,12 +79,18 @@ object Main extends IOWebApp {
                         } yield ()
                       })
                     )
-      changeSource <- button(
+
+      updateSource<- button(
                         `type` := "button",
-                        "Reload Source",
+                        "Load Source",
                         onClick(_ =>
                           for {
-                            _ <- events.set(ec.getEvents)
+                            start <- startRef.get
+                            end   <- endRef.get
+                            inst  <- instanceRef.get
+                            live  <- liveRef.get
+                            _     <- (liveRef.set(false)).whenA(live)
+                            _     <- events.set(ec.getEvents(start.toString(), end.toString(), inst))
                           } yield ()
                         )
                       )
@@ -92,15 +98,16 @@ object Main extends IOWebApp {
       sup         <- Supervisor[IO](await=true)
 
       //any changes to any of these signallingrefs should trigger a getevents call
-      params      = (startRef.asInstanceOf[Signal[IO, LocalDateTime]], 
-                     endRef.asInstanceOf[Signal[IO, LocalDateTime]], 
-                     instanceRef.asInstanceOf[Signal[IO, String]],
-                     liveRef.asInstanceOf[Signal[IO, Boolean]]).mapN{
-                      (start, end, instance, live) => (start, end, instance)
-                    }
+      params      = liveRef.asInstanceOf[Signal[IO, Boolean]]
 
-      _           <- Resource.eval(sup.supervise(params.discrete.switchMap { (s, e, i) => 
-                        Stream.exec(events.set(ec.getEvents(s.toString(), e.toString(), i)))
+      _           <- Resource.eval(sup.supervise(params.discrete.drop(1).switchMap { _ => 
+                        Stream.exec(
+                          for {
+                            s      <- startRef.get
+                            e      <- endRef.get
+                            i      <- instanceRef.get
+                            strmIO <- events.set(ec.getEvents(s.toString(), e.toString(), i))
+                          } yield strmIO)
                   }.compile.drain).void)
 
       //probably don't need this anymore since we're combining signal in params
@@ -125,8 +132,8 @@ object Main extends IOWebApp {
       //                   } yield()
       //                 }.compile.drain).void)
 
-      timeRange   <- new TimeRangeComponent(startRef, endRef, liveRef).render
-      timeSelect  <- div(idAttr:= "time-selection", liveButton, timeRange)  
+      timeRange   <- new TimeRangeComponent(startRef, endRef).render
+      timeSelect  <- div(idAttr:= "time-selection", liveButton, timeRange, updateSource)  
 
       zoomRef     <- Resource.eval(Ref[IO].of(1.0))
       zoom        <- new ZoomComponent(zoomRef).render

--- a/modules/frontend/src/main/scala/latis/logviz/Main.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/Main.scala
@@ -7,7 +7,6 @@ import calico.IOWebApp
 import calico.html.io.{*, given}
 import cats.effect.IO
 import cats.effect.Resource
-import cats.syntax.all.*
 import fs2.Stream
 import cats.effect.kernel.Ref
 import fs2.concurrent.SignallingRef
@@ -82,14 +81,13 @@ object Main extends IOWebApp {
 
       updateSource<- button(
                         `type` := "button",
-                        "Load Source",
+                        "Load Events",
                         onClick(_ =>
                           for {
                             start <- startRef.get
                             end   <- endRef.get
                             inst  <- instanceRef.get
-                            live  <- liveRef.get
-                            _     <- (liveRef.set(false)).whenA(live)
+                            _     <- liveRef.set(false)
                             _     <- events.set(ec.getEvents(start.toString(), end.toString(), inst))
                           } yield ()
                         )
@@ -133,7 +131,7 @@ object Main extends IOWebApp {
       //                 }.compile.drain).void)
 
       timeRange   <- new TimeRangeComponent(startRef, endRef).render
-      timeSelect  <- div(idAttr:= "time-selection", liveButton, timeRange, updateSource)  
+      timeSelect  <- div(idAttr:= "time-selection", timeRange, updateSource)  
 
       zoomRef     <- Resource.eval(Ref[IO].of(1.0))
       zoom        <- new ZoomComponent(zoomRef).render

--- a/modules/frontend/src/main/scala/latis/logviz/TimeRangeComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/TimeRangeComponent.scala
@@ -26,7 +26,7 @@ class TimeRangeComponent(
       
       startInput  <- div(
                       idAttr := "start-time",
-                      p("Start: "),
+                      label("Start: "),
                       input.withSelf{ self => 
                         (
                           `type` := "datetime-local",
@@ -54,7 +54,7 @@ class TimeRangeComponent(
                     ) 
       endInput    <- div(
                       idAttr := "end-time",
-                      p("End: "),
+                      label("End: "),
                       input.withSelf{ self => 
                         (
                           idAttr := "end-time",

--- a/modules/frontend/src/main/scala/latis/logviz/TimeRangeComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/TimeRangeComponent.scala
@@ -15,8 +15,7 @@ import fs2.dom.HtmlElement
 
 class TimeRangeComponent(
   startRef: SignallingRef[IO, LocalDateTime],
-  endRef: SignallingRef[IO, LocalDateTime],
-  liveRef: SignallingRef[IO, Boolean]
+  endRef: SignallingRef[IO, LocalDateTime]
 ) {
   val formatter= DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
   def render: Resource[IO, HtmlElement[IO]] =
@@ -73,10 +72,7 @@ class TimeRangeComponent(
                                 Either.catchOnly[DateTimeParseException](LocalDateTime.parse(v)) match
                                   case Left(value) => throw new IllegalArgumentException(
                                     "Invalid time") 
-                                  case Right(value) => {
-                                    liveRef.set(false) >>
-                                    endRef.set(value)
-                                  }
+                                  case Right(value) => endRef.set(value)
                               } else {
                                 IO.unit
                               }
@@ -86,7 +82,7 @@ class TimeRangeComponent(
                       },
                       span(cls := "validity")
                     )
-      test  <- div(idAttr:= "time-range", div(idAttr:= "time-selection", startInput, endInput))
+      test  <- div(idAttr:= "time-range", div(idAttr:= "time-range-selection", startInput, endInput))
 
     } yield(test)
   


### PR DESCRIPTION
I added some formatting to the button to make it a little more intuitive that you can change the instance and times and then hit "Load Source". The only times there should be a `getEvents()` call should be updating whether the timescale is live or not, or when the button is pressed. 