### PR TITLE
Fix "bad" instance selection

### DIFF
--- a/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
@@ -60,14 +60,14 @@ class EventComponent(
       timeline      <- div(idAttr:= "timeline", canvasIO, sizer)
       canvas        =  canvasIO.asInstanceOf[HTMLCanvasElement]
       context       =  canvas.getContext("2d").asInstanceOf[dom.CanvasRenderingContext2D]
-      eParser       <- Resource.eval(EventParser(startTime))
+      eParser       <- Resource.eval(EventParser(startTime.get))
       parserRef     <- Resource.eval(Ref[IO].of(eParser))
       parserUpdated <- Resource.eval(Ref[IO].of(false))
       alertRef      <- Resource.eval(Ref[IO].of(true))
       _             <- Resource.eval(sup.supervise(signal.discrete.drop(1).switchMap { eventStream => 
                         // making a new parser
                         val newParser = for {
-                          parser <- EventParser(startTime)
+                          parser <- EventParser(startTime.get)
                           _      <- parserRef.set(parser)
                           _      <- alertRef.set(true)
                         } yield parser

--- a/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
@@ -60,14 +60,15 @@ class EventComponent(
       timeline      <- div(idAttr:= "timeline", canvasIO, sizer)
       canvas        =  canvasIO.asInstanceOf[HTMLCanvasElement]
       context       =  canvas.getContext("2d").asInstanceOf[dom.CanvasRenderingContext2D]
-      eParser       <- Resource.eval(EventParser(startTime.get))
+      eParser       <- Resource.eval(startTime.get.flatMap(EventParser(_)))
       parserRef     <- Resource.eval(Ref[IO].of(eParser))
       parserUpdated <- Resource.eval(Ref[IO].of(false))
       alertRef      <- Resource.eval(Ref[IO].of(true))
       _             <- Resource.eval(sup.supervise(signal.discrete.drop(1).switchMap { eventStream => 
                         // making a new parser
                         val newParser = for {
-                          parser <- EventParser(startTime.get)
+                          start  <- startTime.get
+                          parser <- EventParser(start)
                           _      <- parserRef.set(parser)
                           _      <- alertRef.set(true)
                         } yield parser

--- a/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventComponent.scala
@@ -60,14 +60,14 @@ class EventComponent(
       timeline      <- div(idAttr:= "timeline", canvasIO, sizer)
       canvas        =  canvasIO.asInstanceOf[HTMLCanvasElement]
       context       =  canvas.getContext("2d").asInstanceOf[dom.CanvasRenderingContext2D]
-      eParser       <- Resource.eval(EventParser())
+      eParser       <- Resource.eval(EventParser(startTime))
       parserRef     <- Resource.eval(Ref[IO].of(eParser))
       parserUpdated <- Resource.eval(Ref[IO].of(false))
       alertRef      <- Resource.eval(Ref[IO].of(true))
       _             <- Resource.eval(sup.supervise(signal.discrete.drop(1).switchMap { eventStream => 
                         // making a new parser
                         val newParser = for {
-                          parser <- EventParser()
+                          parser <- EventParser(startTime)
                           _      <- parserRef.set(parser)
                           _      <- alertRef.set(true)
                         } yield parser

--- a/modules/frontend/src/main/scala/latis/logviz/EventParser.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventParser.scala
@@ -1,9 +1,13 @@
 package latis.logviz
 
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
 import cats.effect.IO
 import cats.effect.kernel.Ref
 import cats.effect.std.PQueue
 import cats.syntax.all.*
+import fs2.concurrent.SignallingRef
 
 import latis.logviz.model.RequestEvent
 import latis.logviz.model.Event
@@ -20,7 +24,7 @@ trait EventParser {
  * Keeping track of the maximum number of concurrent events at a time to determine number of columns to draw
 */
 object EventParser {
-  def apply(): IO[EventParser] = {
+  def apply(startTime: SignallingRef[IO, LocalDateTime]): IO[EventParser] = {
     for {
       //ongoing request events mapped to concurrent depth
       eventsRef 		<- Ref[IO].of(Map[String, (RequestEvent, Column)]())
@@ -153,10 +157,22 @@ object EventParser {
                             >> IO(currDepth)
 
                           case Some((RequestEvent.Partial(start, status), currDepth)) =>
-                            compEventsRef.update(lst =>
-                              (RequestEvent.Partial(time, s"successful event with response status of: $status, duration: $duration"), 
-                              currDepth) +: lst)
-                            >> IO(currDepth)
+                            for {
+                              start <- startTime.get
+                              successTime = LocalDateTime.parse(time)
+                              // if we should have had a partial request event and we don't, discard, otherwise update the partial event 
+                              eventStart = successTime.minus(duration, ChronoUnit.MILLIS)
+                              d     <- if (start.isAfter(eventStart)) {
+                                        // a valid partial event, update it
+                                        compEventsRef.update(lst =>
+                                          (RequestEvent.Partial(time, s"successful event with response status of: $status, duration: $duration"), 
+                                          currDepth) +: lst)
+                                        >> IO(currDepth)
+                                      } else {
+                                        // we should have had a partial request event and we don't
+                                        IO(currDepth.copy(used = false))
+                                      }
+                            } yield d
 
                           case Some((_, currDepth)) => 
                             colCounter.update(c => c - 1) >>

--- a/modules/frontend/src/main/scala/latis/logviz/EventParser.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventParser.scala
@@ -7,7 +7,6 @@ import cats.effect.IO
 import cats.effect.kernel.Ref
 import cats.effect.std.PQueue
 import cats.syntax.all.*
-import fs2.concurrent.SignallingRef
 
 import latis.logviz.model.RequestEvent
 import latis.logviz.model.Event
@@ -24,7 +23,7 @@ trait EventParser {
  * Keeping track of the maximum number of concurrent events at a time to determine number of columns to draw
 */
 object EventParser {
-  def apply(startTime: SignallingRef[IO, LocalDateTime]): IO[EventParser] = {
+  def apply(startTime: IO[LocalDateTime]): IO[EventParser] = {
     for {
       //ongoing request events mapped to concurrent depth
       eventsRef 		<- Ref[IO].of(Map[String, (RequestEvent, Column)]())
@@ -158,7 +157,7 @@ object EventParser {
 
                           case Some((RequestEvent.Partial(start, status), currDepth)) =>
                             for {
-                              start <- startTime.get
+                              start <- startTime
                               successTime = LocalDateTime.parse(time)
                               // if we should have had a partial request event and we don't, discard, otherwise update the partial event 
                               eventStart = successTime.minus(duration, ChronoUnit.MILLIS)

--- a/modules/frontend/src/main/scala/latis/logviz/EventParser.scala
+++ b/modules/frontend/src/main/scala/latis/logviz/EventParser.scala
@@ -23,7 +23,7 @@ trait EventParser {
  * Keeping track of the maximum number of concurrent events at a time to determine number of columns to draw
 */
 object EventParser {
-  def apply(startTime: IO[LocalDateTime]): IO[EventParser] = {
+  def apply(startTime: LocalDateTime): IO[EventParser] = {
     for {
       //ongoing request events mapped to concurrent depth
       eventsRef 		<- Ref[IO].of(Map[String, (RequestEvent, Column)]())
@@ -156,22 +156,19 @@ object EventParser {
                             >> IO(currDepth)
 
                           case Some((RequestEvent.Partial(start, status), currDepth)) =>
-                            for {
-                              start <- startTime
-                              successTime = LocalDateTime.parse(time)
-                              // if we should have had a partial request event and we don't, discard, otherwise update the partial event 
-                              eventStart = successTime.minus(duration, ChronoUnit.MILLIS)
-                              d     <- if (start.isAfter(eventStart)) {
-                                        // a valid partial event, update it
-                                        compEventsRef.update(lst =>
-                                          (RequestEvent.Partial(time, s"successful event with response status of: $status, duration: $duration"), 
-                                          currDepth) +: lst)
-                                        >> IO(currDepth)
-                                      } else {
-                                        // we should have had a partial request event and we don't
-                                        IO(currDepth.copy(used = false))
-                                      }
-                            } yield d
+                            val successTime = LocalDateTime.parse(time)
+                            // if we should have had a partial request event and we don't, discard, otherwise update the partial event 
+                            val eventStart = successTime.minus(duration, ChronoUnit.MILLIS)
+                            if (startTime.isAfter(eventStart)) {
+                              // a valid partial event, update it
+                              compEventsRef.update(lst =>
+                                (RequestEvent.Partial(time, s"successful event with response status of: $status, duration: $duration"), 
+                                currDepth) +: lst)
+                              >> IO(currDepth)
+                            } else {
+                              // we should have had a partial request event and we don't
+                              IO(currDepth.copy(used = false))
+                            }
 
                           case Some((_, currDepth)) => 
                             colCounter.update(c => c - 1) >>

--- a/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkClient.scala
+++ b/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkClient.scala
@@ -195,12 +195,20 @@ object SplunkClient {
                 val time = spl(0).split(" INFO")(0).drop(1)
                 val request = line.split("HTTP/1.1 GET")(1).drop(1)
                 Some(Event.Request(id, time, request))
+              else if line.contains("HTTP/1.1 POST") then
+                val spl = line.split("HTTP/1.1 POST")
+                val id = spl(0).split("request-id=")(1).dropRight(3)
+                val time = spl(0).split(" INFO")(0).drop(1)
+                val request = line.split("HTTP/1.1 POST")(1).drop(1)
+                Some(Event.Request(id, time, request))
               else if line.contains("HTTP/1.1 ") then
                 val spl = line.split("HTTP/1.1 ")
                 val id = spl(0).split("request-id=")(1).dropRight(3)
                 val time = spl(0).split(" INFO")(0).drop(1)
-                val status = spl(1).split(" ")(0).toInt
-                Some(Event.Response(id, time, status))
+                spl(1).split(" ")(0)
+                  .toIntOption
+                  .map(status => Some(Event.Response(id, time, status)))
+                  .getOrElse(None)
               else if line.contains("Elapsed ") then
                 val spl = line.split("Elapsed ")
                 val id = spl(0).split("request-id=")(1).dropRight(3)
@@ -257,6 +265,9 @@ object SplunkClient {
 
             val basicQuery = s"search index=$index source=$source earliest_time=$eTime latest_time=$lTime"
             val query = if (source == "latis3-lisird-7") {
+              val innerQuery = basicQuery + """ Content-Length: 6981 | rex field=line "^[^=\n]*=(?P<request_id>[^\)]+)" | table request_id"""
+              basicQuery + s" NOT [$innerQuery] | reverse"
+            } else if (source == "latis3-lisird-6") {
               val innerQuery = basicQuery + """ Content-Length: 6981 | rex field=line "^[^=\n]*=(?P<request_id>[^\)]+)" | table request_id"""
               basicQuery + s" NOT [$innerQuery] | reverse"
             } else if (source == "latis3-aim-11") {

--- a/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkClient.scala
+++ b/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkClient.scala
@@ -262,23 +262,7 @@ object SplunkClient {
             // make the query from args
             val eTime = start.toEpochSecond(ZoneOffset.UTC).toString()
             val lTime = end.toEpochSecond(ZoneOffset.UTC).toString()
-
-            val basicQuery = s"search index=$index source=$source earliest_time=$eTime latest_time=$lTime"
-            val query = if (source == "latis3-lisird-7") {
-              val innerQuery = basicQuery + """ Content-Length: 6981 | rex field=line "^[^=\n]*=(?P<request_id>[^\)]+)" | table request_id"""
-              basicQuery + s" NOT [$innerQuery] | reverse"
-            } else if (source == "latis3-lisird-6") {
-              val innerQuery = basicQuery + """ Content-Length: 6981 | rex field=line "^[^=\n]*=(?P<request_id>[^\)]+)" | table request_id"""
-              basicQuery + s" NOT [$innerQuery] | reverse"
-            } else if (source == "latis3-aim-11") {
-              val innerQuery = basicQuery + """ Content-Length: 24719 | rex field=line "^[^=\n]*=(?P<request_id>[^\)]+)" | table request_id"""
-              basicQuery + s" NOT [$innerQuery] | reverse"
-            } else if (source == "latis3-packets-cute-9") {
-              val innerQuery = basicQuery + """ Content-Length: 224 | rex field=line "^[^=\n]*=(?P<request_id>[^\)]+)" | table request_id"""
-              basicQuery + s" NOT [$innerQuery] | reverse"
-            } else {
-              s"search index=$index source=$source earliest_time=$eTime latest_time=$lTime | reverse"
-            }
+            val query = s"search index=$index source=$source earliest_time=$eTime latest_time=$lTime | reverse"
 
             Stream.eval {
               for {

--- a/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkClient.scala
+++ b/modules/splunk/src/main/scala/latis/logviz/splunk/SplunkClient.scala
@@ -254,7 +254,20 @@ object SplunkClient {
             // make the query from args
             val eTime = start.toEpochSecond(ZoneOffset.UTC).toString()
             val lTime = end.toEpochSecond(ZoneOffset.UTC).toString()
-            val query = s"search index=$index source=$source earliest_time=$eTime latest_time=$lTime | reverse"
+
+            val basicQuery = s"search index=$index source=$source earliest_time=$eTime latest_time=$lTime"
+            val query = if (source == "latis3-lisird-7") {
+              val innerQuery = basicQuery + """ Content-Length: 6981 | rex field=line "^[^=\n]*=(?P<request_id>[^\)]+)" | table request_id"""
+              basicQuery + s" NOT [$innerQuery] | reverse"
+            } else if (source == "latis3-aim-11") {
+              val innerQuery = basicQuery + """ Content-Length: 24719 | rex field=line "^[^=\n]*=(?P<request_id>[^\)]+)" | table request_id"""
+              basicQuery + s" NOT [$innerQuery] | reverse"
+            } else if (source == "latis3-packets-cute-9") {
+              val innerQuery = basicQuery + """ Content-Length: 224 | rex field=line "^[^=\n]*=(?P<request_id>[^\)]+)" | table request_id"""
+              basicQuery + s" NOT [$innerQuery] | reverse"
+            } else {
+              s"search index=$index source=$source earliest_time=$eTime latest_time=$lTime | reverse"
+            }
 
             Stream.eval {
               for {


### PR DESCRIPTION
Some instances cannot be parsed into events, or are missing a type of event in the logs that are needed for drawing, and will throw this exception: "No unused column available. Increase number of columns!!!" This also breaks the application when it is thrown. Since there is nothing distinct I can find in health check responses and success logs, I changed the query for some instances that throw this error, which checks for the content-length of the health check, then removes all events that have a request-id correlating to a health check. 